### PR TITLE
Clean up old generation segments on commit

### DIFF
--- a/index/segment_info.go
+++ b/index/segment_info.go
@@ -54,6 +54,19 @@ func (si *SegmentInfos) WritePending(dir store.Directory) (string, string, error
 	return pendingName, finalName, nil
 }
 
+// ReferencedFiles returns the set of all files referenced by the current commit:
+// the segments_N file itself plus all files listed in each SegmentCommitInfo.
+func (si *SegmentInfos) ReferencedFiles() map[string]bool {
+	refs := make(map[string]bool)
+	refs[fmt.Sprintf("segments_%d", si.Generation)] = true
+	for _, info := range si.Segments {
+		for _, f := range info.Files {
+			refs[f] = true
+		}
+	}
+	return refs
+}
+
 // ReadLatestSegmentInfos reads the most recent segments_N file from the directory.
 func ReadLatestSegmentInfos(dir store.Directory) (*SegmentInfos, error) {
 	files, err := dir.ListAll()

--- a/index/segment_info_test.go
+++ b/index/segment_info_test.go
@@ -117,6 +117,36 @@ func TestReadLatestSegmentInfosNoFile(t *testing.T) {
 	}
 }
 
+func TestReferencedFiles(t *testing.T) {
+	si := &SegmentInfos{
+		Generation: 2,
+		Segments: []*SegmentCommitInfo{
+			{Name: "_seg0", Files: []string{"_seg0.meta", "_seg0.body.tidx"}},
+			{Name: "_seg1", Files: []string{"_seg1.meta", "_seg1.del"}},
+		},
+	}
+
+	refs := si.ReferencedFiles()
+
+	// Should contain the segments file itself
+	if !refs["segments_2"] {
+		t.Error("expected segments_2 in referenced files")
+	}
+	// Should contain all segment files
+	for _, want := range []string{"_seg0.meta", "_seg0.body.tidx", "_seg1.meta", "_seg1.del"} {
+		if !refs[want] {
+			t.Errorf("expected %q in referenced files", want)
+		}
+	}
+	// Should not contain unrelated files
+	if refs["segments_1"] {
+		t.Error("segments_1 should not be in referenced files")
+	}
+	if refs["_seg2.meta"] {
+		t.Error("_seg2.meta should not be in referenced files")
+	}
+}
+
 func TestSegmentCommitInfoFields(t *testing.T) {
 	info := &SegmentCommitInfo{
 		Name:     "_seg0",

--- a/index/writer.go
+++ b/index/writer.go
@@ -6,6 +6,7 @@ import (
 	"gosearch/document"
 	"gosearch/store"
 	"sort"
+	"strings"
 )
 
 // DeleteTerm represents a buffered delete-by-term operation.
@@ -52,6 +53,15 @@ func NewIndexWriter(dir store.Directory, analyzer *analysis.Analyzer, bufferSize
 	} else {
 		// No existing state — start fresh.
 		w.segmentInfos = NewSegmentInfos()
+	}
+
+	// Clean up any stale pending_segments_* files from prior crashes.
+	if files, err := dir.ListAll(); err == nil {
+		for _, f := range files {
+			if strings.HasPrefix(f, "pending_segments_") {
+				_ = dir.DeleteFile(f)
+			}
+		}
 	}
 
 	w.buffer = newInMemorySegment(w.nextSegmentName())
@@ -204,7 +214,7 @@ func (w *IndexWriter) Commit() error {
 			if err != nil {
 				return fmt.Errorf("write deletions for %s: %w", info.Name, err)
 			}
-			if delFile != "" {
+			if delFile != "" && !containsString(info.Files, delFile) {
 				info.Files = append(info.Files, delFile)
 			}
 		}
@@ -236,7 +246,14 @@ func (w *IndexWriter) Commit() error {
 	}
 
 	// 8. Fsync directory to make the rename durable
-	return w.dir.SyncMetaData()
+	if err := w.dir.SyncMetaData(); err != nil {
+		return err
+	}
+
+	// 9. Best-effort cleanup of stale files
+	w.deleteStaleFiles()
+
+	return nil
 }
 
 // applyPendingDeletes resolves all buffered delete terms against disk segments.
@@ -334,6 +351,51 @@ func (w *IndexWriter) Close() error {
 		delete(w.readerMap, name)
 	}
 	return nil
+}
+
+// deleteStaleFiles removes old segments_N files, stale pending_segments_* files,
+// and orphaned segment data files not referenced by the current commit.
+// All deletions are best-effort — errors are silently ignored.
+func (w *IndexWriter) deleteStaleFiles() {
+	files, err := w.dir.ListAll()
+	if err != nil {
+		return
+	}
+
+	refs := w.segmentInfos.ReferencedFiles()
+
+	for _, f := range files {
+		switch {
+		case isOldSegmentsFile(f, w.segmentInfos.Generation):
+			_ = w.dir.DeleteFile(f)
+		case strings.HasPrefix(f, "pending_segments_"):
+			_ = w.dir.DeleteFile(f)
+		case strings.HasPrefix(f, "_seg") && !refs[f]:
+			_ = w.dir.DeleteFile(f)
+		}
+	}
+}
+
+// isOldSegmentsFile returns true if f is a segments_N file with generation < current.
+func isOldSegmentsFile(f string, currentGen int64) bool {
+	if !strings.HasPrefix(f, "segments_") {
+		return false
+	}
+	var gen int64
+	if _, err := fmt.Sscanf(f, "segments_%d", &gen); err == nil {
+		return gen < currentGen
+	}
+	return false
+}
+
+// containsString reports whether slice contains s.
+func containsString(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
 }
 
 func (w *IndexWriter) getOrCreateFieldIndex(seg *InMemorySegment, fieldName string) *FieldIndex {

--- a/index/writer_test.go
+++ b/index/writer_test.go
@@ -876,3 +876,155 @@ func TestNewWriterGenerationContinuity(t *testing.T) {
 		t.Errorf("TotalDocCount: got %d, want 2", reader.TotalDocCount())
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Tests for stale file cleanup
+// ---------------------------------------------------------------------------
+
+func TestCommitCleansUpOldSegmentsFile(t *testing.T) {
+	analyzer := analysis.NewAnalyzer(
+		analysis.NewWhitespaceTokenizer(),
+		&analysis.LowerCaseFilter{},
+	)
+	dir, _ := store.NewFSDirectory(t.TempDir())
+	writer := NewIndexWriter(dir, analyzer, 100)
+
+	// First commit → segments_1
+	doc := document.NewDocument()
+	doc.AddField("body", "hello", document.FieldTypeText)
+	writer.AddDocument(doc)
+	if err := writer.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if !dir.FileExists("segments_1") {
+		t.Fatal("segments_1 should exist after first commit")
+	}
+
+	// Second commit → segments_2, should delete segments_1
+	doc2 := document.NewDocument()
+	doc2.AddField("body", "world", document.FieldTypeText)
+	writer.AddDocument(doc2)
+	if err := writer.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !dir.FileExists("segments_2") {
+		t.Error("segments_2 should exist after second commit")
+	}
+	if dir.FileExists("segments_1") {
+		t.Error("segments_1 should have been cleaned up after second commit")
+	}
+}
+
+func TestCommitCleansUpStalePendingFiles(t *testing.T) {
+	analyzer := analysis.NewAnalyzer(
+		analysis.NewWhitespaceTokenizer(),
+		&analysis.LowerCaseFilter{},
+	)
+	dir, _ := store.NewFSDirectory(t.TempDir())
+
+	// Simulate a leftover pending file from a prior crash
+	out, _ := dir.CreateOutput("pending_segments_99")
+	out.Write([]byte("stale"))
+	out.Close()
+
+	writer := NewIndexWriter(dir, analyzer, 100)
+
+	doc := document.NewDocument()
+	doc.AddField("body", "hello", document.FieldTypeText)
+	writer.AddDocument(doc)
+	if err := writer.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	if dir.FileExists("pending_segments_99") {
+		t.Error("pending_segments_99 should have been cleaned up after commit")
+	}
+}
+
+func TestNewWriterCleansUpStalePendingFiles(t *testing.T) {
+	analyzer := analysis.NewAnalyzer(
+		analysis.NewWhitespaceTokenizer(),
+		&analysis.LowerCaseFilter{},
+	)
+	dir, _ := store.NewFSDirectory(t.TempDir())
+
+	// Simulate leftover pending files
+	out, _ := dir.CreateOutput("pending_segments_1")
+	out.Write([]byte("stale"))
+	out.Close()
+	out2, _ := dir.CreateOutput("pending_segments_5")
+	out2.Write([]byte("stale"))
+	out2.Close()
+
+	// Creating a new writer should clean up pending files
+	_ = NewIndexWriter(dir, analyzer, 100)
+
+	if dir.FileExists("pending_segments_1") {
+		t.Error("pending_segments_1 should have been cleaned up on writer startup")
+	}
+	if dir.FileExists("pending_segments_5") {
+		t.Error("pending_segments_5 should have been cleaned up on writer startup")
+	}
+}
+
+func TestCommitPreservesCurrentSegmentFiles(t *testing.T) {
+	analyzer := analysis.NewAnalyzer(
+		analysis.NewWhitespaceTokenizer(),
+		&analysis.LowerCaseFilter{},
+	)
+	dir, _ := store.NewFSDirectory(t.TempDir())
+	writer := NewIndexWriter(dir, analyzer, 100)
+
+	doc := document.NewDocument()
+	doc.AddField("body", "hello world", document.FieldTypeText)
+	writer.AddDocument(doc)
+	if err := writer.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Collect all files referenced by the current commit
+	refs := writer.segmentInfos.ReferencedFiles()
+
+	// Verify all referenced files still exist on disk
+	for f := range refs {
+		if !dir.FileExists(f) {
+			t.Errorf("referenced file %q should still exist after commit", f)
+		}
+	}
+}
+
+func TestCommitCleansUpOrphanedSegmentFiles(t *testing.T) {
+	analyzer := analysis.NewAnalyzer(
+		analysis.NewWhitespaceTokenizer(),
+		&analysis.LowerCaseFilter{},
+	)
+	dir, _ := store.NewFSDirectory(t.TempDir())
+
+	// Create an orphaned segment file (not referenced by any commit)
+	out, _ := dir.CreateOutput("_seg99.meta")
+	out.Write([]byte("orphaned"))
+	out.Close()
+
+	writer := NewIndexWriter(dir, analyzer, 100)
+
+	doc := document.NewDocument()
+	doc.AddField("body", "hello", document.FieldTypeText)
+	writer.AddDocument(doc)
+	if err := writer.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	if dir.FileExists("_seg99.meta") {
+		t.Error("orphaned _seg99.meta should have been cleaned up after commit")
+	}
+
+	// Verify real segment files still exist
+	for _, info := range writer.segmentInfos.Segments {
+		for _, f := range info.Files {
+			if !dir.FileExists(f) {
+				t.Errorf("current segment file %q should still exist", f)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add `SegmentInfos.ReferencedFiles()` to compute the set of files referenced by the current commit
- Add `IndexWriter.deleteStaleFiles()` called after each successful commit to remove:
  - Old `segments_N` files from previous generations
  - Orphaned `_seg*` data files not referenced by the current commit
  - Stale `pending_segments_*` files from crashed commits
- Clean up `pending_segments_*` files on `NewIndexWriter` startup (crash recovery)
- Fix `.del` file duplication — prevent appending duplicate entries on repeated commits with deletes

## Test plan

- [x] `TestReferencedFiles` — verifies correct file set from `SegmentInfos.ReferencedFiles()`
- [x] `TestCommitCleansUpOldSegmentsFile` — after 2 commits, `segments_1` is deleted, `segments_2` remains
- [x] `TestCommitCleansUpStalePendingFiles` — leftover `pending_segments_*` deleted after commit
- [x] `TestNewWriterCleansUpStalePendingFiles` — `NewIndexWriter` deletes stale pending files on startup
- [x] `TestCommitPreservesCurrentSegmentFiles` — cleanup doesn't delete files needed by current commit
- [x] `TestCommitCleansUpOrphanedSegmentFiles` — files from segments removed from SegmentInfos are deleted
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)