### PR TITLE
Refactor IndexSearcher to accept Query interface

### DIFF
--- a/index/e2e_test.go
+++ b/index/e2e_test.go
@@ -46,7 +46,7 @@ func TestE2EDiskSegmentSearch(t *testing.T) {
 	defer reader.Close()
 
 	searcher := search.NewIndexSearcher(reader)
-	results := searcher.Search("body", "fox", 10)
+	results := searcher.Search(search.NewTermQuery("body", "fox"), 10)
 
 	// "fox" appears in doc0 (seg0) and doc2 (seg1)
 	if len(results) != 2 {
@@ -74,7 +74,7 @@ func TestE2EDiskSegmentSearch(t *testing.T) {
 	}
 	defer nrtReader.Close()
 	nrtSearcher := search.NewIndexSearcher(nrtReader)
-	nrtResults := nrtSearcher.Search("body", "fox", 10)
+	nrtResults := nrtSearcher.Search(search.NewTermQuery("body", "fox"), 10)
 
 	if len(results) != len(nrtResults) {
 		t.Fatalf("result count mismatch: disk=%d, nrt=%d", len(results), len(nrtResults))

--- a/search/bm25_test.go
+++ b/search/bm25_test.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"sort"
 	"testing"
 
 	"gosearch/analysis"
@@ -57,12 +58,17 @@ func TestBM25Scoring(t *testing.T) {
 	defer reader.Close()
 	seg := reader.Leaves()[0].Segment
 
-	results := TermSearch(seg, "body", "fox", 10)
+	results := NewTermQuery("body", "fox").Execute(seg)
 
 	// Only doc0 and doc1 should match
 	if len(results) != 2 {
 		t.Fatalf("expected 2 results, got %d", len(results))
 	}
+
+	// Sort by score descending to verify ranking
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Score > results[j].Score
+	})
 
 	// doc0 should rank higher (short doc with higher TF)
 	if results[0].DocID != 0 {

--- a/search/searcher.go
+++ b/search/searcher.go
@@ -18,53 +18,21 @@ func NewIndexSearcher(reader *index.IndexReader) *IndexSearcher {
 	return &IndexSearcher{reader: reader}
 }
 
-// Search executes a term query across all segments and returns the top-K results.
-func (s *IndexSearcher) Search(field, term string, topK int) []SearchResult {
-	scorer := NewBM25Scorer()
+// Search executes a Query across all segments and returns top-K results.
+func (s *IndexSearcher) Search(q Query, topK int) []SearchResult {
 	collector := NewTopKCollector(topK)
 
-	totalDocCount := s.reader.TotalDocCount()
-
-	// Compute docFreq across all segments (needed for IDF)
-	docFreq := 0
 	for _, leaf := range s.reader.Leaves() {
-		docFreq += leaf.Segment.DocFreq(field, term)
-	}
-
-	if docFreq == 0 {
-		return nil
-	}
-
-	idf := scorer.IDF(totalDocCount, docFreq)
-
-	// Compute avgDocLen across all segments
-	totalLen := 0
-	totalDocs := 0
-	for _, leaf := range s.reader.Leaves() {
-		totalLen += leaf.Segment.TotalFieldLength(field)
-		totalDocs += leaf.Segment.DocCount()
-	}
-	avgDocLen := 0.0
-	if totalDocs > 0 {
-		avgDocLen = float64(totalLen) / float64(totalDocs)
-	}
-
-	// Search each segment
-	for _, leaf := range s.reader.Leaves() {
-		iter := leaf.Segment.PostingsIterator(field, term)
-		for iter.Next() {
-			if leaf.Segment.IsDeleted(iter.DocID()) {
+		results := q.Execute(leaf.Segment)
+		for _, ds := range results {
+			if leaf.Segment.IsDeleted(ds.DocID) {
 				continue
 			}
-
-			docLen := float64(leaf.Segment.FieldLength(field, iter.DocID()))
-			score := scorer.Score(float64(iter.Freq()), docLen, avgDocLen, idf)
-			globalDocID := leaf.DocBase + iter.DocID()
-
-			stored, _ := leaf.Segment.StoredFields(iter.DocID())
+			globalDocID := leaf.DocBase + ds.DocID
+			stored, _ := leaf.Segment.StoredFields(ds.DocID)
 			collector.Collect(SearchResult{
 				DocID:  globalDocID,
-				Score:  score,
+				Score:  ds.Score,
 				Fields: stored,
 			})
 		}
@@ -73,54 +41,3 @@ func (s *IndexSearcher) Search(field, term string, topK int) []SearchResult {
 	return collector.Results()
 }
 
-// SimpleSearch searches for a single term in the given field and returns matching documents.
-func SimpleSearch(seg index.SegmentReader, field, term string) []SearchResult {
-	iter := seg.PostingsIterator(field, term)
-
-	var results []SearchResult
-	for iter.Next() {
-		stored, _ := seg.StoredFields(iter.DocID())
-		results = append(results, SearchResult{
-			DocID:  iter.DocID(),
-			Score:  1.0,
-			Fields: stored,
-		})
-	}
-	return results
-}
-
-// TermSearch searches for a single term with BM25 scoring and returns the top-K results.
-func TermSearch(seg index.SegmentReader, field, term string, topK int) []SearchResult {
-	docFreq := seg.DocFreq(field, term)
-	if docFreq == 0 {
-		return nil
-	}
-
-	scorer := NewBM25Scorer()
-
-	docCount := seg.DocCount()
-	idf := scorer.IDF(docCount, docFreq)
-
-	totalFieldLen := seg.TotalFieldLength(field)
-	avgDocLen := 0.0
-	if docCount > 0 {
-		avgDocLen = float64(totalFieldLen) / float64(docCount)
-	}
-
-	collector := NewTopKCollector(topK)
-
-	iter := seg.PostingsIterator(field, term)
-	for iter.Next() {
-		docLen := float64(seg.FieldLength(field, iter.DocID()))
-		score := scorer.Score(float64(iter.Freq()), docLen, avgDocLen, idf)
-
-		stored, _ := seg.StoredFields(iter.DocID())
-		collector.Collect(SearchResult{
-			DocID:  iter.DocID(),
-			Score:  score,
-			Fields: stored,
-		})
-	}
-
-	return collector.Results()
-}


### PR DESCRIPTION
Suggested PR details:                                                             

  Title: Refactor IndexSearcher to accept Query interface

  Body:
  ## Summary
  - Replace `Search(field, term string, topK int)` with `Search(q Query, topK int)` to
   support all Query types
  - Remove redundant `SimpleSearch` and `TermSearch` functions (now superseded by
  `TermQuery`)
  - Update tests to use the new API

  ## Test plan
  - [x] `go test ./search/...` passes
  - [x] `go test ./index/...` passes
  - [x] Verified TermQuery, PhraseQuery, and BooleanQuery work with the new Search
  method