### PR TITLE
fix(bulk): align bulk API with Elasticsearch behavior

### DIFF
--- a/server/action/bulk.go
+++ b/server/action/bulk.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"time"
 
+	"gosearch/search"
 	"gosearch/server/cluster"
 	"gosearch/server/index"
 )
 
 type BulkItem struct {
-	Action string          // "index" or "delete"
+	Action string // "index", "create", or "delete"
 	Index  string
 	ID     string
 	Source json.RawMessage // nil for delete
@@ -58,65 +59,148 @@ func (a *TransportBulkAction) Name() string {
 	return "indices:data/write/bulk"
 }
 
+// shardKey identifies a target shard for grouping bulk items.
+type shardKey struct {
+	index   string
+	shardID int
+}
+
+// bulkItemWithIndex pairs a bulk item with its original position in the request.
+type bulkItemWithIndex struct {
+	item    BulkItem
+	origIdx int
+}
+
 func (a *TransportBulkAction) Execute(req BulkRequest) (BulkResponse, error) {
 	start := time.Now()
 
-	items := make([]BulkItemResponse, 0, len(req.Items))
+	responses := make([]BulkItemResponse, len(req.Items))
 	hasErrors := false
 
-	for _, item := range req.Items {
-		resp := BulkItemResponse{
-			Action: item.Action,
-			Index:  item.Index,
-			ID:     item.ID,
-		}
+	// Phase 1: Resolve shards and group items.
+	// Items that fail validation (e.g. missing index) are recorded immediately.
+	groups := make(map[shardKey][]bulkItemWithIndex)
+	var order []shardKey
 
-		err := a.executeItem(item)
-		if err != nil {
+	for i, item := range req.Items {
+		svc := a.indexServices[item.Index]
+		if a.clusterState.Metadata().Indices[item.Index] == nil || svc == nil {
 			hasErrors = true
-			resp.Status = 400
-			resp.Error = &ErrorDetail{
-				Type:   "action_request_validation_exception",
-				Reason: err.Error(),
+			responses[i] = BulkItemResponse{
+				Action: item.Action,
+				Index:  item.Index,
+				ID:     item.ID,
+				Status: 404,
+				Error: &ErrorDetail{
+					Type:   "index_not_found_exception",
+					Reason: fmt.Sprintf("no such index [%s]", item.Index),
+				},
 			}
-		} else {
-			switch item.Action {
-			case "index", "create":
-				resp.Status = 201
-			case "delete":
-				resp.Status = 200
-			}
+			continue
 		}
 
-		items = append(items, resp)
+		sid := index.RouteShard(item.ID, svc.NumShards())
+		key := shardKey{index: item.Index, shardID: sid}
+
+		if _, exists := groups[key]; !exists {
+			order = append(order, key)
+		}
+		groups[key] = append(groups[key], bulkItemWithIndex{
+			item:    item,
+			origIdx: i,
+		})
+	}
+
+	// Phase 2: Execute items grouped by shard.
+	for _, key := range order {
+		items := groups[key]
+		svc := a.indexServices[key.index]
+		shard := svc.Shard(key.shardID)
+
+		for _, bi := range items {
+			resp := BulkItemResponse{
+				Action: bi.item.Action,
+				Index:  bi.item.Index,
+				ID:     bi.item.ID,
+			}
+
+			err := a.executeItemOnShard(shard, bi.item)
+			if err != nil {
+				hasErrors = true
+				resp.Status = errorStatusCode(err)
+				resp.Error = &ErrorDetail{
+					Type:   errorType(err),
+					Reason: err.Error(),
+				}
+			} else {
+				switch bi.item.Action {
+				case "index", "create":
+					resp.Status = 201
+				case "delete":
+					resp.Status = 200
+				}
+			}
+
+			responses[bi.origIdx] = resp
+		}
 	}
 
 	return BulkResponse{
 		Took:   time.Since(start).Milliseconds(),
 		Errors: hasErrors,
-		Items:  items,
+		Items:  responses,
 	}, nil
 }
 
-func (a *TransportBulkAction) executeItem(item BulkItem) error {
-	if a.clusterState.Metadata().Indices[item.Index] == nil {
-		return fmt.Errorf("no such index [%s]", item.Index)
-	}
-
-	svc := a.indexServices[item.Index]
-	if svc == nil {
-		return fmt.Errorf("no such index [%s]", item.Index)
-	}
-
-	shardID := index.RouteShard(item.ID, svc.NumShards())
-	shard := svc.Shard(shardID)
-
+// executeItemOnShard runs a single bulk item against the given shard.
+func (a *TransportBulkAction) executeItemOnShard(shard *index.IndexShard, item BulkItem) error {
 	switch item.Action {
-	case "index", "create":
+	case "create":
+		if docExists(shard, item.ID) {
+			return &VersionConflictError{ID: item.ID, Index: item.Index}
+		}
+		return shard.Index(item.ID, item.Source)
+	case "index":
 		return shard.Index(item.ID, item.Source)
 	case "delete":
 		return shard.Delete(item.ID)
 	default:
 		return fmt.Errorf("unknown bulk action [%s]", item.Action)
 	}
+}
+
+// docExists checks whether a document with the given ID exists in the shard.
+func docExists(shard *index.IndexShard, id string) bool {
+	searcher := shard.Searcher()
+	if searcher == nil {
+		return false
+	}
+	query := search.NewTermQuery("_id", id)
+	collector := search.NewTopKCollector(1)
+	results := searcher.Search(query, collector)
+	return len(results) > 0
+}
+
+// VersionConflictError is returned when a create operation targets an existing document.
+type VersionConflictError struct {
+	ID    string
+	Index string
+}
+
+func (e *VersionConflictError) Error() string {
+	return fmt.Sprintf("[%s]: version conflict, document already exists (current version [1])", e.ID)
+}
+
+func errorType(err error) string {
+	if _, ok := err.(*VersionConflictError); ok {
+		return "version_conflict_engine_exception"
+	}
+	return "action_request_validation_exception"
+}
+
+func errorStatusCode(err error) int {
+	if _, ok := err.(*VersionConflictError); ok {
+		return 409
+	}
+	return 400
 }

--- a/server/action/bulk_test.go
+++ b/server/action/bulk_test.go
@@ -79,6 +79,12 @@ func TestTransportBulkAction_PartialErrors(t *testing.T) {
 	if resp.Items[1].Error == nil {
 		t.Error("second item should fail for nonexistent index")
 	}
+	if resp.Items[1].Status != 404 {
+		t.Errorf("expected status 404 for missing index, got %d", resp.Items[1].Status)
+	}
+	if resp.Items[1].Error.Type != "index_not_found_exception" {
+		t.Errorf("expected error type index_not_found_exception, got %s", resp.Items[1].Error.Type)
+	}
 }
 
 func TestTransportBulkAction_CreateAction(t *testing.T) {
@@ -114,5 +120,130 @@ func TestTransportBulkAction_CreateAction(t *testing.T) {
 	}
 	if resp.Items[0].Status != 201 {
 		t.Errorf("expected status 201, got %d", resp.Items[0].Status)
+	}
+}
+
+func TestTransportBulkAction_CreateConflict(t *testing.T) {
+	cs, services, dataPath, registry := newTestDeps(t)
+
+	createIdxAction := NewTransportCreateIndexAction(cs, services, dataPath, registry)
+	createIdxAction.Execute(CreateIndexRequest{
+		Name: "docs",
+		Mappings: &mapping.MappingDefinition{
+			Properties: map[string]mapping.FieldMapping{
+				"title": {Type: mapping.FieldTypeText},
+			},
+		},
+	})
+	defer services["docs"].Close()
+
+	// Index a document first, then refresh so it becomes visible.
+	bulkAction := NewTransportBulkAction(cs, services)
+	bulkAction.Execute(BulkRequest{
+		Items: []BulkItem{
+			{Action: "index", Index: "docs", ID: "1", Source: json.RawMessage(`{"title":"original"}`)},
+		},
+	})
+	svc := services["docs"]
+	svc.Shard(0).Refresh()
+
+	// Attempt to "create" a document with the same ID should fail.
+	resp, err := bulkAction.Execute(BulkRequest{
+		Items: []BulkItem{
+			{Action: "create", Index: "docs", ID: "1", Source: json.RawMessage(`{"title":"duplicate"}`)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !resp.Errors {
+		t.Fatal("expected Errors=true for create conflict")
+	}
+	if resp.Items[0].Status != 409 {
+		t.Errorf("expected status 409, got %d", resp.Items[0].Status)
+	}
+	if resp.Items[0].Error.Type != "version_conflict_engine_exception" {
+		t.Errorf("expected version_conflict_engine_exception, got %s", resp.Items[0].Error.Type)
+	}
+}
+
+func TestTransportBulkAction_IndexOverwrites(t *testing.T) {
+	cs, services, dataPath, registry := newTestDeps(t)
+
+	createIdxAction := NewTransportCreateIndexAction(cs, services, dataPath, registry)
+	createIdxAction.Execute(CreateIndexRequest{
+		Name: "docs",
+		Mappings: &mapping.MappingDefinition{
+			Properties: map[string]mapping.FieldMapping{
+				"title": {Type: mapping.FieldTypeText},
+			},
+		},
+	})
+	defer services["docs"].Close()
+
+	bulkAction := NewTransportBulkAction(cs, services)
+
+	// Index, refresh, then index again with same ID — should succeed (overwrite).
+	bulkAction.Execute(BulkRequest{
+		Items: []BulkItem{
+			{Action: "index", Index: "docs", ID: "1", Source: json.RawMessage(`{"title":"original"}`)},
+		},
+	})
+	services["docs"].Shard(0).Refresh()
+
+	resp, err := bulkAction.Execute(BulkRequest{
+		Items: []BulkItem{
+			{Action: "index", Index: "docs", ID: "1", Source: json.RawMessage(`{"title":"updated"}`)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if resp.Errors {
+		t.Errorf("expected no errors for index overwrite, got: %+v", resp.Items)
+	}
+	if resp.Items[0].Status != 201 {
+		t.Errorf("expected status 201, got %d", resp.Items[0].Status)
+	}
+}
+
+func TestTransportBulkAction_ResponseOrderPreserved(t *testing.T) {
+	cs, services, dataPath, registry := newTestDeps(t)
+
+	createIdxAction := NewTransportCreateIndexAction(cs, services, dataPath, registry)
+	createIdxAction.Execute(CreateIndexRequest{
+		Name: "docs",
+		Mappings: &mapping.MappingDefinition{
+			Properties: map[string]mapping.FieldMapping{
+				"title": {Type: mapping.FieldTypeText},
+			},
+		},
+	})
+	defer services["docs"].Close()
+
+	bulkAction := NewTransportBulkAction(cs, services)
+
+	// Mix of valid and invalid items — response order must match request order.
+	resp, err := bulkAction.Execute(BulkRequest{
+		Items: []BulkItem{
+			{Action: "index", Index: "docs", ID: "a", Source: json.RawMessage(`{"title":"a"}`)},
+			{Action: "index", Index: "missing", ID: "b", Source: json.RawMessage(`{"title":"b"}`)},
+			{Action: "index", Index: "docs", ID: "c", Source: json.RawMessage(`{"title":"c"}`)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(resp.Items) != 3 {
+		t.Fatalf("expected 3 responses, got %d", len(resp.Items))
+	}
+	if resp.Items[0].ID != "a" || resp.Items[0].Error != nil {
+		t.Errorf("item 0: expected success for ID=a, got %+v", resp.Items[0])
+	}
+	if resp.Items[1].ID != "b" || resp.Items[1].Error == nil {
+		t.Errorf("item 1: expected error for ID=b, got %+v", resp.Items[1])
+	}
+	if resp.Items[2].ID != "c" || resp.Items[2].Error != nil {
+		t.Errorf("item 2: expected success for ID=c, got %+v", resp.Items[2])
 	}
 }


### PR DESCRIPTION
## Summary
- **Shard grouping**: Bulk items are now grouped by shard before processing, matching ES's `TransportShardBulkAction` pattern. Response order is preserved regardless of grouping.
- **index vs create distinction**: `create` now returns `409 version_conflict_engine_exception` if the document already exists. `index` continues to overwrite as before.
- **Error code improvement**: Missing index errors now return `404 index_not_found_exception` instead of `400`.

## Test plan
- [x] Existing tests updated and passing
- [x] New test: `TestTransportBulkAction_CreateConflict` — create on existing doc returns 409
- [x] New test: `TestTransportBulkAction_IndexOverwrites` — index on existing doc succeeds
- [x] New test: `TestTransportBulkAction_ResponseOrderPreserved` — response order matches request order despite shard grouping
- [x] All package tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)