### PR TITLE
refactor: unify Field struct to use single Value any field

### DIFF
--- a/document/document.go
+++ b/document/document.go
@@ -23,12 +23,14 @@ const (
 )
 
 // Field represents a single field within a document.
+// Value holds the field's data and its concrete type depends on Type:
+//   - FieldTypeText, FieldTypeKeyword, FieldTypeSortedDocValues: string
+//   - FieldTypeStored: string or []byte
+//   - FieldTypeNumericDocValues, FieldTypeLongPoint, FieldTypeDoublePoint: int64
 type Field struct {
-	Name         string
-	Value        string
-	BytesValue   []byte // used for binary stored fields (e.g. _source)
-	Type         FieldType
-	NumericValue int64 // used when Type == FieldTypeNumericDocValues
+	Name  string
+	Value any
+	Type  FieldType
 }
 
 // Document represents a single document to be indexed.
@@ -50,17 +52,17 @@ func (d *Document) AddField(name, value string, fieldType FieldType) {
 
 func (d *Document) AddNumericDocValuesField(name string, value int64) {
 	d.Fields = append(d.Fields, Field{
-		Name:         name,
-		Type:         FieldTypeNumericDocValues,
-		NumericValue: value,
+		Name:  name,
+		Type:  FieldTypeNumericDocValues,
+		Value: value,
 	})
 }
 
 func (d *Document) AddBytesField(name string, value []byte, fieldType FieldType) {
 	d.Fields = append(d.Fields, Field{
-		Name:       name,
-		BytesValue: value,
-		Type:       fieldType,
+		Name:  name,
+		Value: value,
+		Type:  fieldType,
 	})
 }
 
@@ -76,9 +78,9 @@ func (d *Document) AddSortedDocValuesField(name string, value string) {
 // and as numeric doc values for sorting. Mirrors Lucene's LongPoint + SortedNumericDocValuesField.
 func (d *Document) AddLongPoint(name string, value int64) {
 	d.Fields = append(d.Fields, Field{
-		Name:         name,
-		Type:         FieldTypeLongPoint,
-		NumericValue: value,
+		Name:  name,
+		Type:  FieldTypeLongPoint,
+		Value: value,
 	})
 }
 
@@ -87,9 +89,9 @@ func (d *Document) AddLongPoint(name string, value int64) {
 // using the same encoding as Lucene's NumericUtils.doubleToSortableLong.
 func (d *Document) AddDoublePoint(name string, value float64) {
 	d.Fields = append(d.Fields, Field{
-		Name:         name,
-		Type:         FieldTypeDoublePoint,
-		NumericValue: DoubleToSortableLong(value),
+		Name:  name,
+		Type:  FieldTypeDoublePoint,
+		Value: DoubleToSortableLong(value),
 	})
 }
 

--- a/document/document_test.go
+++ b/document/document_test.go
@@ -117,8 +117,8 @@ func TestAddLongPoint(t *testing.T) {
 	if field.Type != FieldTypeLongPoint {
 		t.Errorf("field type = %v, want FieldTypeLongPoint", field.Type)
 	}
-	if field.NumericValue != 42 {
-		t.Errorf("numeric value = %d, want 42", field.NumericValue)
+	if field.Value.(int64) != 42 {
+		t.Errorf("numeric value = %d, want 42", field.Value.(int64))
 	}
 }
 
@@ -139,7 +139,7 @@ func TestAddDoublePoint(t *testing.T) {
 	}
 
 	// Verify the stored value can be decoded back to original
-	decoded := SortableLongToDouble(field.NumericValue)
+	decoded := SortableLongToDouble(field.Value.(int64))
 	if decoded != 3.14 {
 		t.Errorf("decoded value = %v, want 3.14", decoded)
 	}

--- a/index/dwpt.go
+++ b/index/dwpt.go
@@ -42,7 +42,8 @@ func (dwpt *DocumentsWriterPerThread) addDocument(doc *document.Document) (int64
 	for _, field := range doc.Fields {
 		switch field.Type {
 		case document.FieldTypeText:
-			tokens, err := dwpt.fieldAnalyzers.AnalyzeField(field.Name, field.Value)
+			strVal := field.Value.(string)
+			tokens, err := dwpt.fieldAnalyzers.AnalyzeField(field.Name, strVal)
 			if err != nil {
 				return 0, err
 			}
@@ -80,23 +81,25 @@ func (dwpt *DocumentsWriterPerThread) addDocument(doc *document.Document) (int64
 			}
 
 		case document.FieldTypeKeyword:
+			strVal := field.Value.(string)
 			fi := dwpt.getOrCreateFieldIndex(field.Name)
-			pl, exists := fi.postings[field.Value]
+			pl, exists := fi.postings[strVal]
 			if !exists {
-				pl = &PostingsList{Term: field.Value}
-				fi.postings[field.Value] = pl
+				pl = &PostingsList{Term: strVal}
+				fi.postings[strVal] = pl
 			}
 			pl.Postings = append(pl.Postings, Posting{
 				DocID: docID, Freq: 1, Positions: []int{0},
 			})
-			bytesAdded += int64(len(field.Value) + 16 + 8)
+			bytesAdded += int64(len(strVal) + 16 + 8)
 
 		case document.FieldTypeNumericDocValues:
+			numVal := field.Value.(int64)
 			vals := seg.numericDocValues[field.Name]
 			if len(vals) <= docID {
 				vals = append(vals, make([]int64, docID+1-len(vals))...)
 			}
-			vals[docID] = field.NumericValue
+			vals[docID] = numVal
 			seg.numericDocValues[field.Name] = vals
 			if seg.numericDocIDs[field.Name] == nil {
 				seg.numericDocIDs[field.Name] = make(map[int]struct{})
@@ -105,20 +108,22 @@ func (dwpt *DocumentsWriterPerThread) addDocument(doc *document.Document) (int64
 			bytesAdded += 8
 
 		case document.FieldTypeSortedDocValues:
+			strVal := field.Value.(string)
 			svals := seg.sortedDocValues[field.Name]
 			if len(svals) <= docID {
 				svals = append(svals, make([]string, docID+1-len(svals))...)
 			}
-			svals[docID] = field.Value
+			svals[docID] = strVal
 			seg.sortedDocValues[field.Name] = svals
-			bytesAdded += int64(len(field.Value))
+			bytesAdded += int64(len(strVal))
 
 		case document.FieldTypeLongPoint, document.FieldTypeDoublePoint:
+			numVal := field.Value.(int64)
 			vals := seg.numericDocValues[field.Name]
 			if len(vals) <= docID {
 				vals = append(vals, make([]int64, docID+1-len(vals))...)
 			}
-			vals[docID] = field.NumericValue
+			vals[docID] = numVal
 			seg.numericDocValues[field.Name] = vals
 			seg.pointFields[field.Name] = struct{}{}
 			if seg.numericDocIDs[field.Name] == nil {
@@ -134,10 +139,11 @@ func (dwpt *DocumentsWriterPerThread) addDocument(doc *document.Document) (int64
 				seg.storedFields[docID] = make(map[string][]byte)
 			}
 			var storedValue []byte
-			if field.BytesValue != nil {
-				storedValue = field.BytesValue
-			} else {
-				storedValue = []byte(field.Value)
+			switch v := field.Value.(type) {
+			case []byte:
+				storedValue = v
+			case string:
+				storedValue = []byte(v)
 			}
 			seg.storedFields[docID][field.Name] = storedValue
 			bytesAdded += int64(len(field.Name) + len(storedValue))

--- a/server/mapping/parser_test.go
+++ b/server/mapping/parser_test.go
@@ -516,8 +516,8 @@ func TestParseDocument_LargeIntegerPrecision(t *testing.T) {
 	for _, f := range doc.Fields {
 		if f.Name == "big_id" && f.Type == document.FieldTypeLongPoint {
 			var want int64 = 9007199254740993
-			if f.NumericValue != want {
-				t.Errorf("big_id numeric = %d, want %d (precision lost)", f.NumericValue, want)
+			if f.Value.(int64) != want {
+				t.Errorf("big_id numeric = %d, want %d (precision lost)", f.Value.(int64), want)
 			}
 			return
 		}
@@ -557,8 +557,8 @@ func TestParseDocument_KeywordHasSortedDocValues(t *testing.T) {
 
 	for _, f := range doc.Fields {
 		if f.Name == "status" && f.Type == document.FieldTypeSortedDocValues {
-			if f.Value != "active" {
-				t.Errorf("sorted doc value = %q, want %q", f.Value, "active")
+			if f.Value.(string) != "active" {
+				t.Errorf("sorted doc value = %q, want %q", f.Value.(string), "active")
 			}
 			return
 		}
@@ -581,8 +581,8 @@ func TestParseDocument_BooleanHasSortedDocValues(t *testing.T) {
 
 	for _, f := range doc.Fields {
 		if f.Name == "active" && f.Type == document.FieldTypeSortedDocValues {
-			if f.Value != "true" {
-				t.Errorf("sorted doc value = %q, want %q", f.Value, "true")
+			if f.Value.(string) != "true" {
+				t.Errorf("sorted doc value = %q, want %q", f.Value.(string), "true")
 			}
 			return
 		}
@@ -595,8 +595,10 @@ func TestParseDocument_BooleanHasSortedDocValues(t *testing.T) {
 func assertHasField(t *testing.T, doc *document.Document, name, value string, ft document.FieldType) {
 	t.Helper()
 	for _, f := range doc.Fields {
-		if f.Name == name && f.Value == value && f.Type == ft {
-			return
+		if f.Name == name && f.Type == ft {
+			if s, ok := f.Value.(string); ok && s == value {
+				return
+			}
 		}
 	}
 	t.Errorf("expected field {Name:%q, Value:%q, Type:%v} not found in document", name, value, ft)
@@ -605,21 +607,25 @@ func assertHasField(t *testing.T, doc *document.Document, name, value string, ft
 func assertHasBytesField(t *testing.T, doc *document.Document, name string, value []byte, ft document.FieldType) {
 	t.Helper()
 	for _, f := range doc.Fields {
-		if f.Name == name && bytes.Equal(f.BytesValue, value) && f.Type == ft {
-			return
+		if f.Name == name && f.Type == ft {
+			if b, ok := f.Value.([]byte); ok && bytes.Equal(b, value) {
+				return
+			}
 		}
 	}
-	t.Errorf("expected bytes field {Name:%q, BytesValue:%q, Type:%v} not found in document", name, value, ft)
+	t.Errorf("expected bytes field {Name:%q, Value:%q, Type:%v} not found in document", name, value, ft)
 }
 
 func assertHasNumericField(t *testing.T, doc *document.Document, name string, value int64) {
 	t.Helper()
 	for _, f := range doc.Fields {
-		if f.Name == name && f.Type == document.FieldTypeNumericDocValues && f.NumericValue == value {
-			return
+		if f.Name == name && f.Type == document.FieldTypeNumericDocValues {
+			if n, ok := f.Value.(int64); ok && n == value {
+				return
+			}
 		}
 	}
-	t.Errorf("expected numeric doc values field {Name:%q, NumericValue:%d} not found", name, value)
+	t.Errorf("expected numeric doc values field {Name:%q, Value:%d} not found", name, value)
 }
 
 func assertFieldCount(t *testing.T, doc *document.Document, name string, expected int) {
@@ -648,11 +654,13 @@ func assertHasNumericDocValues(t *testing.T, doc *document.Document, name string
 func assertHasLongPoint(t *testing.T, doc *document.Document, name string, value int64) {
 	t.Helper()
 	for _, f := range doc.Fields {
-		if f.Name == name && f.Type == document.FieldTypeLongPoint && f.NumericValue == value {
-			return
+		if f.Name == name && f.Type == document.FieldTypeLongPoint {
+			if n, ok := f.Value.(int64); ok && n == value {
+				return
+			}
 		}
 	}
-	t.Errorf("expected long point field {Name:%q, NumericValue:%d, Type:FieldTypeLongPoint} not found", name, value)
+	t.Errorf("expected long point field {Name:%q, Value:%d, Type:FieldTypeLongPoint} not found", name, value)
 }
 
 func assertHasDoublePoint(t *testing.T, doc *document.Document, name string, value float64) {
@@ -660,8 +668,10 @@ func assertHasDoublePoint(t *testing.T, doc *document.Document, name string, val
 	sortableLong := document.DoubleToSortableLong(value)
 
 	for _, f := range doc.Fields {
-		if f.Name == name && f.Type == document.FieldTypeDoublePoint && f.NumericValue == sortableLong {
-			return
+		if f.Name == name && f.Type == document.FieldTypeDoublePoint {
+			if n, ok := f.Value.(int64); ok && n == sortableLong {
+				return
+			}
 		}
 	}
 	t.Errorf("expected double point field {Name:%q, Value:%f, Type:FieldTypeDoublePoint} not found", name, value)


### PR DESCRIPTION
## Summary
- Replaces separate `Value` (string), `BytesValue` ([]byte), and `NumericValue` (int64) fields in `document.Field` with a single `Value any` field
- Follows Lucene's design where `Field.java` uses `Object fieldsData` for all field types
- Prevents struct bloat as new value types are added (e.g. `float64`, `[]int64` for multi-valued points)

## Changes
- **document/document.go**: Unified `Field` struct, updated all factory methods (`AddField`, `AddNumericDocValuesField`, `AddBytesField`, `AddSortedDocValuesField`, `AddLongPoint`, `AddDoublePoint`)
- **index/dwpt.go**: Added type assertions in `addDocument` switch cases and stored field handling
- **document/document_test.go**: Updated field value assertions to use type assertions
- **server/mapping/parser_test.go**: Updated all test helpers (`assertHasField`, `assertHasBytesField`, `assertHasNumericField`, `assertHasLongPoint`, `assertHasDoublePoint`) and inline assertions

## Test plan
- [x] All existing tests pass (`go test ./...` — 17 packages)

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)