### PR TITLE
perf: reduce merge allocations by 87% via FST inline traversal and positions pooling

### DIFF
--- a/fst/fst.go
+++ b/fst/fst.go
@@ -103,6 +103,7 @@ func (f *FST) readArcsAt(nodeAddr int64) []arcInfo {
 
 // Get performs an exact lookup for the given key.
 // Returns the output value and true if found, or (0, false) if not found.
+// This method scans arcs inline to avoid allocating []arcInfo slices.
 func (f *FST) Get(key []byte) (uint64, bool) {
 	if f.input.Length() == 0 {
 		return 0, false
@@ -112,27 +113,115 @@ func (f *FST) Get(key []byte) (uint64, bool) {
 	nodeAddr := f.startNode
 
 	for _, b := range key {
-		arcs := f.readArcsAt(nodeAddr)
-		found := false
-		for _, arc := range arcs {
-			if !arc.isFinal && arc.label == b {
-				output = outputAdd(output, arc.output)
-				nodeAddr = arc.target
-				found = true
-				break
-			}
-		}
-		if !found {
+		target, arcOutput, ok := f.findArc(nodeAddr, b)
+		if !ok {
 			return 0, false
 		}
+		output = outputAdd(output, arcOutput)
+		nodeAddr = target
 	}
 
-	// Check if current node is final (has a final arc)
-	arcs := f.readArcsAt(nodeAddr)
-	for _, arc := range arcs {
-		if arc.isFinal {
-			output = outputAdd(output, arc.output)
-			return output, true
+	// Check if current node has a final arc.
+	finalOutput, ok := f.findFinalOutput(nodeAddr)
+	if !ok {
+		return 0, false
+	}
+	return outputAdd(output, finalOutput), true
+}
+
+// findArc scans arcs at nodeAddr for a regular arc with the given label.
+// Returns (target, output, true) if found, or (0, 0, false) if not.
+func (f *FST) findArc(nodeAddr int64, label byte) (int64, uint64, bool) {
+	input := f.input
+	input.Seek(int(nodeAddr))
+
+	for input.Position() < input.Length() {
+		flags, err := input.ReadByte()
+		if err != nil {
+			return 0, 0, false
+		}
+
+		if flags&bitFinalArc != 0 {
+			// Skip final arc output.
+			if flags&bitHasOutput != 0 {
+				if _, err := input.ReadUvarint(); err != nil {
+					return 0, 0, false
+				}
+			}
+			if flags&bitLastArc != 0 {
+				return 0, 0, false
+			}
+			continue
+		}
+
+		arcLabel, err := input.ReadByte()
+		if err != nil {
+			return 0, 0, false
+		}
+
+		var arcOutput uint64
+		if flags&bitHasOutput != 0 {
+			val, err := input.ReadUvarint()
+			if err != nil {
+				return 0, 0, false
+			}
+			arcOutput = val
+		}
+
+		target, err := input.ReadUvarint()
+		if err != nil {
+			return 0, 0, false
+		}
+
+		if arcLabel == label {
+			return int64(target), arcOutput, true
+		}
+
+		if flags&bitLastArc != 0 {
+			return 0, 0, false
+		}
+	}
+	return 0, 0, false
+}
+
+// findFinalOutput checks if the node at nodeAddr has a final arc and returns its output.
+func (f *FST) findFinalOutput(nodeAddr int64) (uint64, bool) {
+	input := f.input
+	input.Seek(int(nodeAddr))
+
+	for input.Position() < input.Length() {
+		flags, err := input.ReadByte()
+		if err != nil {
+			return 0, false
+		}
+
+		if flags&bitFinalArc != 0 {
+			var finalOutput uint64
+			if flags&bitHasOutput != 0 {
+				val, err := input.ReadUvarint()
+				if err != nil {
+					return 0, false
+				}
+				finalOutput = val
+			}
+			return finalOutput, true
+		}
+
+		// Skip regular arc fields.
+		if _, err := input.ReadByte(); err != nil { // label
+			return 0, false
+		}
+		if flags&bitHasOutput != 0 {
+			if _, err := input.ReadUvarint(); err != nil { // output
+				return 0, false
+			}
+		}
+		if _, err := input.ReadUvarint(); err != nil { // target
+			return 0, false
+		}
+
+		if flags&bitLastArc != 0 {
+			return 0, false
 		}
 	}
 	return 0, false

--- a/fst/iterator.go
+++ b/fst/iterator.go
@@ -2,9 +2,9 @@ package fst
 
 // iterFrame holds the DFS traversal state for one node.
 type iterFrame struct {
-	nodeAddr int64  // byte offset of the current node
-	arcIdx   int    // which arc we're currently processing within this node
-	output   uint64 // accumulated output up to (but not including) arcs at this node
+	arcs   []arcInfo // cached arcs for this node (read once per node visit)
+	arcIdx int       // which arc we're currently processing within this node
+	output uint64    // accumulated output up to (but not including) arcs at this node
 }
 
 // FSTIterator performs a depth-first traversal of an FST, yielding all
@@ -39,11 +39,7 @@ func (it *FSTIterator) Next() bool {
 	if !it.inited {
 		it.inited = true
 		// Push the root node
-		it.stack = append(it.stack, iterFrame{
-			nodeAddr: it.fst.startNode,
-			arcIdx:   0,
-			output:   0,
-		})
+		it.pushFrame(it.fst.startNode, 0)
 		return it.advance()
 	}
 
@@ -60,13 +56,32 @@ func (it *FSTIterator) Value() uint64 {
 	return it.output
 }
 
+// pushFrame reads arcs for the given node and pushes a new frame onto the stack.
+func (it *FSTIterator) pushFrame(nodeAddr int64, output uint64) {
+	arcs := it.fst.readArcsAt(nodeAddr)
+	n := len(it.stack)
+	if n < cap(it.stack) {
+		// Reuse existing frame slot to avoid allocation.
+		it.stack = it.stack[:n+1]
+		frame := &it.stack[n]
+		frame.arcs = arcs
+		frame.arcIdx = 0
+		frame.output = output
+	} else {
+		it.stack = append(it.stack, iterFrame{
+			arcs:   arcs,
+			arcIdx: 0,
+			output: output,
+		})
+	}
+}
+
 // advance performs DFS to find the next final state.
 func (it *FSTIterator) advance() bool {
 	for len(it.stack) > 0 {
 		frame := &it.stack[len(it.stack)-1]
-		arcs := it.fst.readArcsAt(frame.nodeAddr)
 
-		if frame.arcIdx >= len(arcs) {
+		if frame.arcIdx >= len(frame.arcs) {
 			// Pop this frame
 			it.stack = it.stack[:len(it.stack)-1]
 			if len(it.key) > 0 {
@@ -75,7 +90,7 @@ func (it *FSTIterator) advance() bool {
 			continue
 		}
 
-		arc := arcs[frame.arcIdx]
+		arc := frame.arcs[frame.arcIdx]
 		frame.arcIdx++
 
 		if arc.isFinal {
@@ -87,11 +102,7 @@ func (it *FSTIterator) advance() bool {
 		// Regular arc: push target node and continue DFS
 		it.key = append(it.key, arc.label)
 		accumulated := outputAdd(frame.output, arc.output)
-		it.stack = append(it.stack, iterFrame{
-			nodeAddr: arc.target,
-			arcIdx:   0,
-			output:   accumulated,
-		})
+		it.pushFrame(arc.target, accumulated)
 	}
 
 	it.done = true

--- a/index/disk_segment_test.go
+++ b/index/disk_segment_test.go
@@ -162,10 +162,12 @@ func TestDiskSegmentPostingsIterator(t *testing.T) {
 		diskIter := ds.PostingsIterator("title", term)
 		var diskPostings []Posting
 		for diskIter.Next() {
+			// Copy positions since DiskPostingsIterator reuses the slice.
+			pos := append([]int(nil), diskIter.Positions()...)
 			diskPostings = append(diskPostings, Posting{
 				DocID:     diskIter.DocID(),
 				Freq:      diskIter.Freq(),
-				Positions: diskIter.Positions(),
+				Positions: pos,
 			})
 		}
 

--- a/index/merger.go
+++ b/index/merger.go
@@ -464,11 +464,16 @@ func mergeFieldPostingsToDisk(
 	var postings []Posting
 	termBuf := &bytes.Buffer{}
 
+	// Flat arena for position data, reused across terms.
+	// Each Posting.Positions is a sub-slice of this arena.
+	var posArena []int
+
 	for h.Len() > 0 {
 		currentTerm := h[0].term
 
 		// Collect postings from all segments that have this term.
 		postings = postings[:0]
+		posArena = posArena[:0]
 		for h.Len() > 0 && h[0].term == currentTerm {
 			entry := h[0]
 			i := entry.inputIdx
@@ -479,10 +484,13 @@ func mergeFieldPostingsToDisk(
 				if !mapper.IsLive(i, oldDoc) {
 					continue
 				}
+				positions := pi.Positions()
+				posStart := len(posArena)
+				posArena = append(posArena, positions...)
 				postings = append(postings, Posting{
 					DocID:     mapper.Map(i, oldDoc),
 					Freq:      pi.Freq(),
-					Positions: pi.Positions(),
+					Positions: posArena[posStart : posStart+len(positions)],
 				})
 			}
 

--- a/index/postings.go
+++ b/index/postings.go
@@ -92,6 +92,9 @@ func (EmptyPostingsIterator) Advance(int) bool { return false }
 // ---------------------------------------------------------------------------
 
 // DiskPostingsIterator reads postings from a mmap'd .tdat slice using delta decoding.
+//
+// The slice returned by Positions() is reused across Next() calls.
+// Callers that need positions to outlive the next Next() call must copy the slice.
 type DiskPostingsIterator struct {
 	input     *store.MMapIndexInput
 	remaining int // remaining postings to read
@@ -130,7 +133,12 @@ func (it *DiskPostingsIterator) Next() bool {
 		it.remaining = 0
 		return false
 	}
-	it.positions = make([]int, posCount)
+	// Reuse the positions slice capacity to reduce allocations.
+	if posCount <= cap(it.positions) {
+		it.positions = it.positions[:posCount]
+	} else {
+		it.positions = make([]int, posCount)
+	}
 	prevPos := 0
 	for i := range posCount {
 		posDelta, err := it.input.ReadVInt()


### PR DESCRIPTION
## Summary

Fixes #34 — Segment merging was allocating ~19 MB per 1K docs (9.6 GB for 500K docs), causing heavy GC pressure.

- **FST `Get()` rewritten** to scan arcs inline (`findArc`/`findFinalOutput`) instead of allocating `[]arcInfo` slices per node — this was the dominant allocator (54% of total)
- **FST iterator** caches arcs in `iterFrame` (read once per node visit, not once per arc) and reuses stack frame capacity
- **`DiskPostingsIterator`** reuses `positions` slice capacity across `Next()` calls
- **`mergeFieldPostingsToDisk`** uses a flat `posArena` buffer for position data, reset per term

## Benchmark results (2×50K docs merge)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Time | 4,495 ms | 415 ms | **10.8× faster** |
| Total alloc | 1,921 MB | 248 MB | **−87%** |
| Alloc count | 16.3M | 4.6M | **−72%** |

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] `BenchmarkLargeSegmentMerge` confirms allocation reduction
- [x] Updated `disk_segment_test.go` to copy positions (iterator now reuses the slice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)