### PR TITLE
feat: transport layer & serialization framework

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24
 require (
 	github.com/getkin/kin-openapi v0.132.0
 	github.com/go-chi/chi/v5 v5.2.5
+	github.com/google/uuid v1.6.0
 	github.com/oapi-codegen/nethttp-middleware v1.1.2
 	github.com/oapi-codegen/runtime v1.3.1
 )
@@ -13,7 +14,6 @@ require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/server/node/node.go
+++ b/server/node/node.go
@@ -125,12 +125,12 @@ func NewNode(config NodeConfig) (*Node, error) {
 	ts, err := transport.NewTransportService(transport.TransportServiceConfig{
 		BindAddress: fmt.Sprintf(":%d", config.TransportPort),
 		NodeName:    fmt.Sprintf("gosearch-%d", config.HTTPPort),
-		PoolConfigs: map[string]transport.PoolConfig{
-			"generic":          {Workers: numCPU * 4, QueueSize: 1000},
-			"search":           {Workers: numCPU + 1, QueueSize: 1000},
-			"index":            {Workers: numCPU, QueueSize: 200},
-			"transport_worker": {Workers: 0},
-			"cluster_state":    {Workers: 1, QueueSize: 10},
+		PoolConfigs: map[transport.PoolName]transport.PoolConfig{
+			transport.PoolGeneric:         {Workers: numCPU * 4, QueueSize: 1000},
+			transport.PoolSearch:          {Workers: numCPU + 1, QueueSize: 1000},
+			transport.PoolIndex:           {Workers: numCPU, QueueSize: 200},
+			transport.PoolTransportWorker: {Workers: 0},
+			transport.PoolClusterState:    {Workers: 1, QueueSize: 10},
 		},
 	})
 	if err != nil {

--- a/server/node/node.go
+++ b/server/node/node.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"runtime"
 	"time"
 
 	"github.com/getkin/kin-openapi/openapi3filter"
@@ -19,22 +20,25 @@ import (
 	"gosearch/server/gateway"
 	"gosearch/server/handler"
 	"gosearch/server/index"
+	"gosearch/server/transport"
 )
 
 type NodeConfig struct {
-	DataPath string
-	HTTPPort int
+	DataPath      string
+	HTTPPort      int
+	TransportPort int
 }
 
 type Node struct {
-	config        NodeConfig
-	clusterState  *cluster.ClusterState
-	indexServices map[string]*index.IndexService
-	router        chi.Router
-	registry      *analysis.AnalyzerRegistry
-	httpServer    *http.Server
-	listener      net.Listener
-	stopped       bool
+	config           NodeConfig
+	clusterState     *cluster.ClusterState
+	indexServices    map[string]*index.IndexService
+	router           chi.Router
+	registry         *analysis.AnalyzerRegistry
+	httpServer       *http.Server
+	listener         net.Listener
+	transportService *transport.TransportService
+	stopped          bool
 }
 
 func NewNode(config NodeConfig) (*Node, error) {
@@ -116,6 +120,24 @@ func NewNode(config NodeConfig) (*Node, error) {
 
 	n.router = router
 
+	// Create TransportService
+	numCPU := runtime.NumCPU()
+	ts, err := transport.NewTransportService(transport.TransportServiceConfig{
+		BindAddress: fmt.Sprintf(":%d", config.TransportPort),
+		NodeName:    fmt.Sprintf("gosearch-%d", config.HTTPPort),
+		PoolConfigs: map[string]transport.PoolConfig{
+			"generic":          {Workers: numCPU * 4, QueueSize: 1000},
+			"search":           {Workers: numCPU + 1, QueueSize: 1000},
+			"index":            {Workers: numCPU, QueueSize: 200},
+			"transport_worker": {Workers: 0},
+			"cluster_state":    {Workers: 1, QueueSize: 10},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create transport service: %w", err)
+	}
+	n.transportService = ts
+
 	return n, nil
 }
 
@@ -142,6 +164,11 @@ func (n *Node) Stop() error {
 	}
 	n.stopped = true
 
+	// Stop transport service
+	if n.transportService != nil {
+		n.transportService.Stop()
+	}
+
 	// Close all index services
 	for name, svc := range n.indexServices {
 		svc.Close()
@@ -162,4 +189,8 @@ func (n *Node) ClusterState() *cluster.ClusterState {
 
 func (n *Node) IndexService(name string) *index.IndexService {
 	return n.indexServices[name]
+}
+
+func (n *Node) TransportService() *transport.TransportService {
+	return n.transportService
 }

--- a/server/node/node_test.go
+++ b/server/node/node_test.go
@@ -637,3 +637,28 @@ func TestNode_RecoveryAfterRestart(t *testing.T) {
 		t.Errorf("search result does not contain document: %s", searchResult)
 	}
 }
+
+func TestNode_TransportServiceStarts(t *testing.T) {
+	dir := t.TempDir()
+	node, err := NewNode(NodeConfig{
+		DataPath:      dir,
+		HTTPPort:      0,
+		TransportPort: 0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer node.Stop()
+
+	_, err = node.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if node.TransportService() == nil {
+		t.Error("TransportService should not be nil")
+	}
+	if node.TransportService().LocalNode().Address == "" {
+		t.Error("transport address should be set")
+	}
+}

--- a/server/transport/action_writeable.go
+++ b/server/transport/action_writeable.go
@@ -1,0 +1,368 @@
+package transport
+
+import "encoding/json"
+
+// --- IndexDocument ---
+
+type IndexDocumentRequest struct {
+	Index         string
+	ID            string
+	Source        json.RawMessage
+	IfSeqNo       *int64
+	IfPrimaryTerm *int64
+}
+
+func (r *IndexDocumentRequest) WriteTo(out *StreamOutput) error {
+	if err := out.WriteString(r.Index); err != nil {
+		return err
+	}
+	if err := out.WriteString(r.ID); err != nil {
+		return err
+	}
+	if err := out.WriteByteArray(r.Source); err != nil {
+		return err
+	}
+	if err := out.WriteOptionalInt64(r.IfSeqNo); err != nil {
+		return err
+	}
+	return out.WriteOptionalInt64(r.IfPrimaryTerm)
+}
+
+func ReadIndexDocumentRequest(in *StreamInput) (*IndexDocumentRequest, error) {
+	index, err := in.ReadString()
+	if err != nil {
+		return nil, err
+	}
+	id, err := in.ReadString()
+	if err != nil {
+		return nil, err
+	}
+	source, err := in.ReadByteArray()
+	if err != nil {
+		return nil, err
+	}
+	ifSeqNo, err := in.ReadOptionalInt64()
+	if err != nil {
+		return nil, err
+	}
+	ifPrimaryTerm, err := in.ReadOptionalInt64()
+	if err != nil {
+		return nil, err
+	}
+	return &IndexDocumentRequest{
+		Index:         index,
+		ID:            id,
+		Source:        json.RawMessage(source),
+		IfSeqNo:       ifSeqNo,
+		IfPrimaryTerm: ifPrimaryTerm,
+	}, nil
+}
+
+type IndexDocumentResponse struct {
+	Index       string
+	ID          string
+	SeqNo       int64
+	PrimaryTerm int64
+	Result      string
+}
+
+func (r *IndexDocumentResponse) WriteTo(out *StreamOutput) error {
+	if err := out.WriteString(r.Index); err != nil {
+		return err
+	}
+	if err := out.WriteString(r.ID); err != nil {
+		return err
+	}
+	if err := out.WriteVLong(r.SeqNo); err != nil {
+		return err
+	}
+	if err := out.WriteVLong(r.PrimaryTerm); err != nil {
+		return err
+	}
+	return out.WriteString(r.Result)
+}
+
+func ReadIndexDocumentResponse(in *StreamInput) (*IndexDocumentResponse, error) {
+	index, err := in.ReadString()
+	if err != nil {
+		return nil, err
+	}
+	id, err := in.ReadString()
+	if err != nil {
+		return nil, err
+	}
+	seqNo, err := in.ReadVLong()
+	if err != nil {
+		return nil, err
+	}
+	primaryTerm, err := in.ReadVLong()
+	if err != nil {
+		return nil, err
+	}
+	result, err := in.ReadString()
+	if err != nil {
+		return nil, err
+	}
+	return &IndexDocumentResponse{
+		Index:       index,
+		ID:          id,
+		SeqNo:       seqNo,
+		PrimaryTerm: primaryTerm,
+		Result:      result,
+	}, nil
+}
+
+// --- GetDocument ---
+
+type GetDocumentRequest struct {
+	Index string
+	ID    string
+}
+
+func (r *GetDocumentRequest) WriteTo(out *StreamOutput) error {
+	if err := out.WriteString(r.Index); err != nil {
+		return err
+	}
+	return out.WriteString(r.ID)
+}
+
+func ReadGetDocumentRequest(in *StreamInput) (*GetDocumentRequest, error) {
+	index, err := in.ReadString()
+	if err != nil {
+		return nil, err
+	}
+	id, err := in.ReadString()
+	if err != nil {
+		return nil, err
+	}
+	return &GetDocumentRequest{
+		Index: index,
+		ID:    id,
+	}, nil
+}
+
+type GetDocumentResponse struct {
+	Index       string
+	ID          string
+	SeqNo       int64
+	PrimaryTerm int64
+	Found       bool
+	Source      json.RawMessage
+}
+
+func (r *GetDocumentResponse) WriteTo(out *StreamOutput) error {
+	if err := out.WriteString(r.Index); err != nil {
+		return err
+	}
+	if err := out.WriteString(r.ID); err != nil {
+		return err
+	}
+	if err := out.WriteVLong(r.SeqNo); err != nil {
+		return err
+	}
+	if err := out.WriteVLong(r.PrimaryTerm); err != nil {
+		return err
+	}
+	if err := out.WriteBool(r.Found); err != nil {
+		return err
+	}
+	if r.Found {
+		return out.WriteByteArray(r.Source)
+	}
+	return nil
+}
+
+func ReadGetDocumentResponse(in *StreamInput) (*GetDocumentResponse, error) {
+	index, err := in.ReadString()
+	if err != nil {
+		return nil, err
+	}
+	id, err := in.ReadString()
+	if err != nil {
+		return nil, err
+	}
+	seqNo, err := in.ReadVLong()
+	if err != nil {
+		return nil, err
+	}
+	primaryTerm, err := in.ReadVLong()
+	if err != nil {
+		return nil, err
+	}
+	found, err := in.ReadBool()
+	if err != nil {
+		return nil, err
+	}
+	var source json.RawMessage
+	if found {
+		src, err := in.ReadByteArray()
+		if err != nil {
+			return nil, err
+		}
+		source = json.RawMessage(src)
+	}
+	return &GetDocumentResponse{
+		Index:       index,
+		ID:          id,
+		SeqNo:       seqNo,
+		PrimaryTerm: primaryTerm,
+		Found:       found,
+		Source:      source,
+	}, nil
+}
+
+// --- Search ---
+
+type SearchRequestMsg struct {
+	Index     string
+	QueryJSON map[string]any
+	AggsJSON  map[string]any
+	Size      int
+}
+
+func (r *SearchRequestMsg) WriteTo(out *StreamOutput) error {
+	if err := out.WriteString(r.Index); err != nil {
+		return err
+	}
+	if err := out.WriteGenericMap(r.QueryJSON); err != nil {
+		return err
+	}
+	if err := out.WriteGenericMap(r.AggsJSON); err != nil {
+		return err
+	}
+	return out.WriteVInt(int32(r.Size))
+}
+
+func ReadSearchRequestMsg(in *StreamInput) (*SearchRequestMsg, error) {
+	index, err := in.ReadString()
+	if err != nil {
+		return nil, err
+	}
+	queryJSON, err := in.ReadGenericMap()
+	if err != nil {
+		return nil, err
+	}
+	aggsJSON, err := in.ReadGenericMap()
+	if err != nil {
+		return nil, err
+	}
+	size, err := in.ReadVInt()
+	if err != nil {
+		return nil, err
+	}
+	return &SearchRequestMsg{
+		Index:     index,
+		QueryJSON: queryJSON,
+		AggsJSON:  aggsJSON,
+		Size:      int(size),
+	}, nil
+}
+
+type SearchHitMsg struct {
+	Index  string
+	ID     string
+	Score  float64
+	Source json.RawMessage
+}
+
+type SearchResponseMsg struct {
+	Took          int64
+	TotalHits     int
+	TotalRelation string
+	MaxScore      float64
+	Hits          []SearchHitMsg
+	Aggregations  map[string]any
+}
+
+func (r *SearchResponseMsg) WriteTo(out *StreamOutput) error {
+	if err := out.WriteVLong(r.Took); err != nil {
+		return err
+	}
+	if err := out.WriteVInt(int32(r.TotalHits)); err != nil {
+		return err
+	}
+	if err := out.WriteString(r.TotalRelation); err != nil {
+		return err
+	}
+	if err := out.WriteFloat64(r.MaxScore); err != nil {
+		return err
+	}
+	if err := out.WriteVInt(int32(len(r.Hits))); err != nil {
+		return err
+	}
+	for _, hit := range r.Hits {
+		if err := out.WriteString(hit.Index); err != nil {
+			return err
+		}
+		if err := out.WriteString(hit.ID); err != nil {
+			return err
+		}
+		if err := out.WriteFloat64(hit.Score); err != nil {
+			return err
+		}
+		if err := out.WriteByteArray(hit.Source); err != nil {
+			return err
+		}
+	}
+	return out.WriteGenericMap(r.Aggregations)
+}
+
+func ReadSearchResponseMsg(in *StreamInput) (*SearchResponseMsg, error) {
+	took, err := in.ReadVLong()
+	if err != nil {
+		return nil, err
+	}
+	totalHits, err := in.ReadVInt()
+	if err != nil {
+		return nil, err
+	}
+	totalRelation, err := in.ReadString()
+	if err != nil {
+		return nil, err
+	}
+	maxScore, err := in.ReadFloat64()
+	if err != nil {
+		return nil, err
+	}
+	hitCount, err := in.ReadVInt()
+	if err != nil {
+		return nil, err
+	}
+	hits := make([]SearchHitMsg, hitCount)
+	for i := range hits {
+		index, err := in.ReadString()
+		if err != nil {
+			return nil, err
+		}
+		id, err := in.ReadString()
+		if err != nil {
+			return nil, err
+		}
+		score, err := in.ReadFloat64()
+		if err != nil {
+			return nil, err
+		}
+		source, err := in.ReadByteArray()
+		if err != nil {
+			return nil, err
+		}
+		hits[i] = SearchHitMsg{
+			Index:  index,
+			ID:     id,
+			Score:  score,
+			Source: json.RawMessage(source),
+		}
+	}
+	aggs, err := in.ReadGenericMap()
+	if err != nil {
+		return nil, err
+	}
+	return &SearchResponseMsg{
+		Took:          took,
+		TotalHits:     int(totalHits),
+		TotalRelation: totalRelation,
+		MaxScore:      maxScore,
+		Hits:          hits,
+		Aggregations:  aggs,
+	}, nil
+}

--- a/server/transport/action_writeable_test.go
+++ b/server/transport/action_writeable_test.go
@@ -1,0 +1,399 @@
+package transport
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestIndexDocumentRequest_Roundtrip(t *testing.T) {
+	seqNo := int64(5)
+	primaryTerm := int64(1)
+	source := json.RawMessage(`{"field":"value"}`)
+
+	req := &IndexDocumentRequest{
+		Index:         "test-index",
+		ID:            "doc-1",
+		Source:        source,
+		IfSeqNo:       &seqNo,
+		IfPrimaryTerm: &primaryTerm,
+	}
+
+	var buf bytes.Buffer
+	out := NewStreamOutput(&buf)
+	if err := req.WriteTo(out); err != nil {
+		t.Fatal(err)
+	}
+
+	in := NewStreamInput(&buf)
+	got, err := ReadIndexDocumentRequest(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Index != req.Index {
+		t.Errorf("Index: expected %q, got %q", req.Index, got.Index)
+	}
+	if got.ID != req.ID {
+		t.Errorf("ID: expected %q, got %q", req.ID, got.ID)
+	}
+	if !bytes.Equal(got.Source, req.Source) {
+		t.Errorf("Source: expected %s, got %s", req.Source, got.Source)
+	}
+	if got.IfSeqNo == nil || *got.IfSeqNo != *req.IfSeqNo {
+		t.Errorf("IfSeqNo: expected %v, got %v", req.IfSeqNo, got.IfSeqNo)
+	}
+	if got.IfPrimaryTerm == nil || *got.IfPrimaryTerm != *req.IfPrimaryTerm {
+		t.Errorf("IfPrimaryTerm: expected %v, got %v", req.IfPrimaryTerm, got.IfPrimaryTerm)
+	}
+}
+
+func TestIndexDocumentRequest_Roundtrip_NilOptionals(t *testing.T) {
+	source := json.RawMessage(`{"field":"value"}`)
+
+	req := &IndexDocumentRequest{
+		Index:         "test-index",
+		ID:            "doc-1",
+		Source:        source,
+		IfSeqNo:       nil,
+		IfPrimaryTerm: nil,
+	}
+
+	var buf bytes.Buffer
+	out := NewStreamOutput(&buf)
+	if err := req.WriteTo(out); err != nil {
+		t.Fatal(err)
+	}
+
+	in := NewStreamInput(&buf)
+	got, err := ReadIndexDocumentRequest(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Index != req.Index {
+		t.Errorf("Index: expected %q, got %q", req.Index, got.Index)
+	}
+	if got.ID != req.ID {
+		t.Errorf("ID: expected %q, got %q", req.ID, got.ID)
+	}
+	if !bytes.Equal(got.Source, req.Source) {
+		t.Errorf("Source: expected %s, got %s", req.Source, got.Source)
+	}
+	if got.IfSeqNo != nil {
+		t.Errorf("IfSeqNo: expected nil, got %v", *got.IfSeqNo)
+	}
+	if got.IfPrimaryTerm != nil {
+		t.Errorf("IfPrimaryTerm: expected nil, got %v", *got.IfPrimaryTerm)
+	}
+}
+
+func TestIndexDocumentResponse_Roundtrip(t *testing.T) {
+	resp := &IndexDocumentResponse{
+		Index:       "test-index",
+		ID:          "doc-1",
+		SeqNo:       10,
+		PrimaryTerm: 1,
+		Result:      "created",
+	}
+
+	var buf bytes.Buffer
+	out := NewStreamOutput(&buf)
+	if err := resp.WriteTo(out); err != nil {
+		t.Fatal(err)
+	}
+
+	in := NewStreamInput(&buf)
+	got, err := ReadIndexDocumentResponse(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Index != resp.Index {
+		t.Errorf("Index: expected %q, got %q", resp.Index, got.Index)
+	}
+	if got.ID != resp.ID {
+		t.Errorf("ID: expected %q, got %q", resp.ID, got.ID)
+	}
+	if got.SeqNo != resp.SeqNo {
+		t.Errorf("SeqNo: expected %d, got %d", resp.SeqNo, got.SeqNo)
+	}
+	if got.PrimaryTerm != resp.PrimaryTerm {
+		t.Errorf("PrimaryTerm: expected %d, got %d", resp.PrimaryTerm, got.PrimaryTerm)
+	}
+	if got.Result != resp.Result {
+		t.Errorf("Result: expected %q, got %q", resp.Result, got.Result)
+	}
+}
+
+func TestGetDocumentRequest_Roundtrip(t *testing.T) {
+	req := &GetDocumentRequest{
+		Index: "test-index",
+		ID:    "doc-1",
+	}
+
+	var buf bytes.Buffer
+	out := NewStreamOutput(&buf)
+	if err := req.WriteTo(out); err != nil {
+		t.Fatal(err)
+	}
+
+	in := NewStreamInput(&buf)
+	got, err := ReadGetDocumentRequest(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Index != req.Index {
+		t.Errorf("Index: expected %q, got %q", req.Index, got.Index)
+	}
+	if got.ID != req.ID {
+		t.Errorf("ID: expected %q, got %q", req.ID, got.ID)
+	}
+}
+
+func TestGetDocumentResponse_Roundtrip_Found(t *testing.T) {
+	source := json.RawMessage(`{"field":"value"}`)
+
+	resp := &GetDocumentResponse{
+		Index:       "test-index",
+		ID:          "doc-1",
+		SeqNo:       5,
+		PrimaryTerm: 1,
+		Found:       true,
+		Source:      source,
+	}
+
+	var buf bytes.Buffer
+	out := NewStreamOutput(&buf)
+	if err := resp.WriteTo(out); err != nil {
+		t.Fatal(err)
+	}
+
+	in := NewStreamInput(&buf)
+	got, err := ReadGetDocumentResponse(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Index != resp.Index {
+		t.Errorf("Index: expected %q, got %q", resp.Index, got.Index)
+	}
+	if got.ID != resp.ID {
+		t.Errorf("ID: expected %q, got %q", resp.ID, got.ID)
+	}
+	if got.SeqNo != resp.SeqNo {
+		t.Errorf("SeqNo: expected %d, got %d", resp.SeqNo, got.SeqNo)
+	}
+	if got.PrimaryTerm != resp.PrimaryTerm {
+		t.Errorf("PrimaryTerm: expected %d, got %d", resp.PrimaryTerm, got.PrimaryTerm)
+	}
+	if got.Found != resp.Found {
+		t.Errorf("Found: expected %v, got %v", resp.Found, got.Found)
+	}
+	if !bytes.Equal(got.Source, resp.Source) {
+		t.Errorf("Source: expected %s, got %s", resp.Source, got.Source)
+	}
+}
+
+func TestGetDocumentResponse_Roundtrip_NotFound(t *testing.T) {
+	resp := &GetDocumentResponse{
+		Index:       "test-index",
+		ID:          "doc-1",
+		SeqNo:       0,
+		PrimaryTerm: 0,
+		Found:       false,
+		Source:      nil,
+	}
+
+	var buf bytes.Buffer
+	out := NewStreamOutput(&buf)
+	if err := resp.WriteTo(out); err != nil {
+		t.Fatal(err)
+	}
+
+	in := NewStreamInput(&buf)
+	got, err := ReadGetDocumentResponse(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Index != resp.Index {
+		t.Errorf("Index: expected %q, got %q", resp.Index, got.Index)
+	}
+	if got.ID != resp.ID {
+		t.Errorf("ID: expected %q, got %q", resp.ID, got.ID)
+	}
+	if got.SeqNo != resp.SeqNo {
+		t.Errorf("SeqNo: expected %d, got %d", resp.SeqNo, got.SeqNo)
+	}
+	if got.PrimaryTerm != resp.PrimaryTerm {
+		t.Errorf("PrimaryTerm: expected %d, got %d", resp.PrimaryTerm, got.PrimaryTerm)
+	}
+	if got.Found != resp.Found {
+		t.Errorf("Found: expected %v, got %v", resp.Found, got.Found)
+	}
+	if got.Source != nil {
+		t.Errorf("Source: expected nil, got %s", got.Source)
+	}
+}
+
+func TestSearchRequest_Roundtrip(t *testing.T) {
+	req := &SearchRequestMsg{
+		Index: "test-index",
+		QueryJSON: map[string]any{
+			"match": map[string]any{
+				"field": "value",
+			},
+		},
+		AggsJSON: map[string]any{
+			"my_agg": map[string]any{
+				"terms": map[string]any{
+					"field": "category",
+				},
+			},
+		},
+		Size: 10,
+	}
+
+	var buf bytes.Buffer
+	out := NewStreamOutput(&buf)
+	if err := req.WriteTo(out); err != nil {
+		t.Fatal(err)
+	}
+
+	in := NewStreamInput(&buf)
+	got, err := ReadSearchRequestMsg(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Index != req.Index {
+		t.Errorf("Index: expected %q, got %q", req.Index, got.Index)
+	}
+	if got.Size != req.Size {
+		t.Errorf("Size: expected %d, got %d", req.Size, got.Size)
+	}
+
+	// Verify nested query JSON
+	queryMatch, ok := got.QueryJSON["match"].(map[string]any)
+	if !ok {
+		t.Fatalf("QueryJSON[match]: expected map[string]any, got %T", got.QueryJSON["match"])
+	}
+	if queryMatch["field"] != "value" {
+		t.Errorf("QueryJSON[match][field]: expected %q, got %v", "value", queryMatch["field"])
+	}
+
+	// Verify nested aggs JSON
+	aggDef, ok := got.AggsJSON["my_agg"].(map[string]any)
+	if !ok {
+		t.Fatalf("AggsJSON[my_agg]: expected map[string]any, got %T", got.AggsJSON["my_agg"])
+	}
+	terms, ok := aggDef["terms"].(map[string]any)
+	if !ok {
+		t.Fatalf("AggsJSON[my_agg][terms]: expected map[string]any, got %T", aggDef["terms"])
+	}
+	if terms["field"] != "category" {
+		t.Errorf("AggsJSON[my_agg][terms][field]: expected %q, got %v", "category", terms["field"])
+	}
+}
+
+func TestSearchResponse_Roundtrip(t *testing.T) {
+	resp := &SearchResponseMsg{
+		Took:          15,
+		TotalHits:     2,
+		TotalRelation: "eq",
+		MaxScore:      1.5,
+		Hits: []SearchHitMsg{
+			{
+				Index:  "test-index",
+				ID:     "doc-1",
+				Score:  1.5,
+				Source: json.RawMessage(`{"field":"value1"}`),
+			},
+			{
+				Index:  "test-index",
+				ID:     "doc-2",
+				Score:  1.2,
+				Source: json.RawMessage(`{"field":"value2"}`),
+			},
+		},
+		Aggregations: map[string]any{
+			"my_agg": map[string]any{
+				"buckets": []any{
+					map[string]any{
+						"key":       "cat1",
+						"doc_count": int64(5),
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	out := NewStreamOutput(&buf)
+	if err := resp.WriteTo(out); err != nil {
+		t.Fatal(err)
+	}
+
+	in := NewStreamInput(&buf)
+	got, err := ReadSearchResponseMsg(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Took != resp.Took {
+		t.Errorf("Took: expected %d, got %d", resp.Took, got.Took)
+	}
+	if got.TotalHits != resp.TotalHits {
+		t.Errorf("TotalHits: expected %d, got %d", resp.TotalHits, got.TotalHits)
+	}
+	if got.TotalRelation != resp.TotalRelation {
+		t.Errorf("TotalRelation: expected %q, got %q", resp.TotalRelation, got.TotalRelation)
+	}
+	if got.MaxScore != resp.MaxScore {
+		t.Errorf("MaxScore: expected %v, got %v", resp.MaxScore, got.MaxScore)
+	}
+	if len(got.Hits) != len(resp.Hits) {
+		t.Fatalf("Hits length: expected %d, got %d", len(resp.Hits), len(got.Hits))
+	}
+
+	for i, hit := range resp.Hits {
+		gotHit := got.Hits[i]
+		if gotHit.Index != hit.Index {
+			t.Errorf("Hit[%d].Index: expected %q, got %q", i, hit.Index, gotHit.Index)
+		}
+		if gotHit.ID != hit.ID {
+			t.Errorf("Hit[%d].ID: expected %q, got %q", i, hit.ID, gotHit.ID)
+		}
+		if gotHit.Score != hit.Score {
+			t.Errorf("Hit[%d].Score: expected %v, got %v", i, hit.Score, gotHit.Score)
+		}
+		if !bytes.Equal(gotHit.Source, hit.Source) {
+			t.Errorf("Hit[%d].Source: expected %s, got %s", i, hit.Source, gotHit.Source)
+		}
+	}
+
+	// Verify aggregations
+	aggDef, ok := got.Aggregations["my_agg"].(map[string]any)
+	if !ok {
+		t.Fatalf("Aggregations[my_agg]: expected map[string]any, got %T", got.Aggregations["my_agg"])
+	}
+	buckets, ok := aggDef["buckets"].([]any)
+	if !ok {
+		t.Fatalf("Aggregations[my_agg][buckets]: expected []any, got %T", aggDef["buckets"])
+	}
+	if len(buckets) != 1 {
+		t.Fatalf("Aggregations[my_agg][buckets] length: expected 1, got %d", len(buckets))
+	}
+	bucket, ok := buckets[0].(map[string]any)
+	if !ok {
+		t.Fatalf("Aggregations[my_agg][buckets][0]: expected map[string]any, got %T", buckets[0])
+	}
+	if bucket["key"] != "cat1" {
+		t.Errorf("Aggregations[my_agg][buckets][0][key]: expected %q, got %v", "cat1", bucket["key"])
+	}
+	if bucket["doc_count"] != int64(5) {
+		t.Errorf("Aggregations[my_agg][buckets][0][doc_count]: expected 5, got %v", bucket["doc_count"])
+	}
+}

--- a/server/transport/channel.go
+++ b/server/transport/channel.go
@@ -1,0 +1,103 @@
+package transport
+
+import (
+	"bytes"
+	"io"
+	"sync"
+)
+
+// TransportChannel is used by request handlers to send responses back.
+type TransportChannel interface {
+	SendResponse(response Writeable) error
+	SendError(err error) error
+}
+
+// TcpTransportChannel writes serialized responses over a TCP connection.
+type TcpTransportChannel struct {
+	requestID int64
+	writer    io.Writer
+	mu        sync.Mutex
+	responded bool
+}
+
+func NewTcpTransportChannel(requestID int64, writer io.Writer) *TcpTransportChannel {
+	return &TcpTransportChannel{requestID: requestID, writer: writer}
+}
+
+func (c *TcpTransportChannel) SendResponse(response Writeable) error {
+	c.mu.Lock()
+	if c.responded {
+		c.mu.Unlock()
+		return nil
+	}
+	c.responded = true
+	c.mu.Unlock()
+
+	var payload bytes.Buffer
+	out := NewStreamOutput(&payload)
+	if err := response.WriteTo(out); err != nil {
+		return err
+	}
+
+	h := &Header{
+		RequestID: c.requestID,
+		Status:    StatusFlags(0),
+	}
+	return writeMessageWithPayload(c.writer, h, payload.Bytes())
+}
+
+func (c *TcpTransportChannel) SendError(err error) error {
+	c.mu.Lock()
+	if c.responded {
+		c.mu.Unlock()
+		return nil
+	}
+	c.responded = true
+	c.mu.Unlock()
+
+	errMsg := &RemoteTransportError{Message: err.Error()}
+	var payload bytes.Buffer
+	out := NewStreamOutput(&payload)
+	if writeErr := errMsg.WriteTo(out); writeErr != nil {
+		return writeErr
+	}
+
+	h := &Header{
+		RequestID: c.requestID,
+		Status:    StatusFlags(0).WithError(true),
+	}
+	return writeMessageWithPayload(c.writer, h, payload.Bytes())
+}
+
+// writeMessageWithPayload writes a complete message (header + payload) to w.
+func writeMessageWithPayload(w io.Writer, h *Header, payload []byte) error {
+	// Build variable header
+	var varBuf bytes.Buffer
+	varOut := NewStreamOutput(&varBuf)
+	if h.Status.IsRequest() {
+		if err := varOut.WriteString(h.Action); err != nil {
+			return err
+		}
+	}
+	if err := varOut.WriteString(h.ParentTaskID); err != nil {
+		return err
+	}
+	varHeader := varBuf.Bytes()
+
+	// MessageLength = requestID(8) + status(1) + varHeaderLen(4) + varHeader + payload
+	msgLen := int32(8 + 1 + 4 + len(varHeader) + len(payload))
+
+	// Write complete message to buffer first, then single write to connection
+	var msg bytes.Buffer
+	msg.Write([]byte{'E', 'S'})
+	sout := NewStreamOutput(&msg)
+	sout.WriteInt32(msgLen)
+	sout.WriteInt64(h.RequestID)
+	sout.WriteByte(byte(h.Status))
+	sout.WriteInt32(int32(len(varHeader)))
+	msg.Write(varHeader)
+	msg.Write(payload)
+
+	_, err := w.Write(msg.Bytes())
+	return err
+}

--- a/server/transport/channel.go
+++ b/server/transport/channel.go
@@ -1,7 +1,6 @@
 package transport
 
 import (
-	"bytes"
 	"io"
 	"sync"
 )
@@ -33,8 +32,10 @@ func (c *TcpTransportChannel) SendResponse(response Writeable) error {
 	c.responded = true
 	c.mu.Unlock()
 
-	var payload bytes.Buffer
-	out := NewStreamOutput(&payload)
+	payload := getBuffer()
+	defer putBuffer(payload)
+
+	out := NewStreamOutput(payload)
 	if err := response.WriteTo(out); err != nil {
 		return err
 	}
@@ -56,8 +57,10 @@ func (c *TcpTransportChannel) SendError(err error) error {
 	c.mu.Unlock()
 
 	errMsg := &RemoteTransportError{Message: err.Error()}
-	var payload bytes.Buffer
-	out := NewStreamOutput(&payload)
+	payload := getBuffer()
+	defer putBuffer(payload)
+
+	out := NewStreamOutput(payload)
 	if writeErr := errMsg.WriteTo(out); writeErr != nil {
 		return writeErr
 	}
@@ -69,11 +72,39 @@ func (c *TcpTransportChannel) SendError(err error) error {
 	return writeMessageWithPayload(c.writer, h, payload.Bytes())
 }
 
+// SyncWriter serializes concurrent writes to an underlying io.Writer using a mutex.
+// Each Write call is guaranteed not to interleave with any other.
+type SyncWriter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+// NewSyncWriter wraps w so that concurrent Write calls are serialized.
+func NewSyncWriter(w io.Writer) *SyncWriter {
+	return &SyncWriter{w: w}
+}
+
+func (sw *SyncWriter) Write(p []byte) (int, error) {
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+	return sw.w.Write(p)
+}
+
+// Close closes the underlying writer if it implements io.Closer.
+func (sw *SyncWriter) Close() error {
+	if c, ok := sw.w.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
+}
+
 // writeMessageWithPayload writes a complete message (header + payload) to w.
 func writeMessageWithPayload(w io.Writer, h *Header, payload []byte) error {
 	// Build variable header
-	var varBuf bytes.Buffer
-	varOut := NewStreamOutput(&varBuf)
+	varBuf := getBuffer()
+	defer putBuffer(varBuf)
+
+	varOut := NewStreamOutput(varBuf)
 	if h.Status.IsRequest() {
 		if err := varOut.WriteString(h.Action); err != nil {
 			return err
@@ -88,9 +119,11 @@ func writeMessageWithPayload(w io.Writer, h *Header, payload []byte) error {
 	msgLen := int32(8 + 1 + 4 + len(varHeader) + len(payload))
 
 	// Write complete message to buffer first, then single write to connection
-	var msg bytes.Buffer
+	msg := getBuffer()
+	defer putBuffer(msg)
+
 	msg.Write([]byte{'E', 'S'})
-	sout := NewStreamOutput(&msg)
+	sout := NewStreamOutput(msg)
 	sout.WriteInt32(msgLen)
 	sout.WriteInt64(h.RequestID)
 	sout.WriteByte(byte(h.Status))

--- a/server/transport/connection.go
+++ b/server/transport/connection.go
@@ -1,0 +1,44 @@
+package transport
+
+import "time"
+
+// ConnectionType categorizes TCP connections by their purpose.
+type ConnectionType int
+
+const (
+	ConnTypeREG      ConnectionType = iota // general requests
+	ConnTypeBULK                           // bulk indexing
+	ConnTypeSTATE                          // cluster state publication
+	ConnTypeRECOVERY                       // shard recovery
+	ConnTypePING                           // keepalive
+)
+
+// TransportRequestOptions configures per-request transport behavior.
+type TransportRequestOptions struct {
+	ConnType ConnectionType
+	Timeout  time.Duration
+}
+
+// ConnectionProfile configures connection counts per type and timeouts.
+type ConnectionProfile struct {
+	ConnPerType      map[ConnectionType]int
+	ConnectTimeout   time.Duration
+	HandshakeTimeout time.Duration
+	PingInterval     time.Duration
+}
+
+// DefaultConnectionProfile returns the default connection profile following ES defaults.
+func DefaultConnectionProfile() ConnectionProfile {
+	return ConnectionProfile{
+		ConnPerType: map[ConnectionType]int{
+			ConnTypeREG:      6,
+			ConnTypeBULK:     3,
+			ConnTypeSTATE:    1,
+			ConnTypeRECOVERY: 2,
+			ConnTypePING:     1,
+		},
+		ConnectTimeout:   30 * time.Second,
+		HandshakeTimeout: 10 * time.Second,
+		PingInterval:     25 * time.Second,
+	}
+}

--- a/server/transport/connection_manager.go
+++ b/server/transport/connection_manager.go
@@ -1,0 +1,72 @@
+package transport
+
+import "sync"
+
+// ConnectionManager manages connections to remote nodes.
+type ConnectionManager struct {
+	transport   *TcpTransport
+	profile     ConnectionProfile
+	connections map[string]*NodeConnection // nodeID → connection
+	mu          sync.RWMutex
+}
+
+func NewConnectionManager(transport *TcpTransport, profile ConnectionProfile) *ConnectionManager {
+	return &ConnectionManager{
+		transport:   transport,
+		profile:     profile,
+		connections: make(map[string]*NodeConnection),
+	}
+}
+
+func (cm *ConnectionManager) Connect(node DiscoveryNode) error {
+	conn, err := cm.transport.OpenConnection(node, cm.profile)
+	if err != nil {
+		return err
+	}
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	if old, ok := cm.connections[node.ID]; ok {
+		old.Close()
+	}
+	cm.connections[node.ID] = conn
+	return nil
+}
+
+func (cm *ConnectionManager) GetConnection(nodeID string) (*NodeConnection, error) {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	conn, ok := cm.connections[nodeID]
+	if !ok {
+		return nil, &NodeNotConnectedError{NodeID: nodeID}
+	}
+	return conn, nil
+}
+
+func (cm *ConnectionManager) DisconnectFromNode(nodeID string) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	if conn, ok := cm.connections[nodeID]; ok {
+		conn.Close()
+		delete(cm.connections, nodeID)
+	}
+}
+
+func (cm *ConnectionManager) ConnectedNodes() []DiscoveryNode {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	nodes := make([]DiscoveryNode, 0, len(cm.connections))
+	for _, conn := range cm.connections {
+		nodes = append(nodes, conn.node)
+	}
+	return nodes
+}
+
+func (cm *ConnectionManager) Close() error {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	for id, conn := range cm.connections {
+		conn.Close()
+		delete(cm.connections, id)
+	}
+	return nil
+}

--- a/server/transport/connection_manager_test.go
+++ b/server/transport/connection_manager_test.go
@@ -8,12 +8,12 @@ import (
 
 func newTestServer(t *testing.T) *TcpTransport {
 	t.Helper()
-	tp := NewThreadPool(map[string]PoolConfig{"generic": {Workers: 2, QueueSize: 10}})
-	t.Cleanup(tp.Shutdown)
+	wp := NewWorkerPool(map[PoolName]PoolConfig{PoolGeneric: {Workers: 2, QueueSize: 10}})
+	t.Cleanup(wp.Shutdown)
 	rh := NewRequestHandlerMap()
 	resph := NewResponseHandlers()
 	node := DiscoveryNode{ID: "server", Name: "server"}
-	transport := NewTcpTransport(node, rh, resph, tp)
+	transport := NewTcpTransport(node, rh, resph, wp)
 	addr, err := transport.Start("127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
@@ -36,10 +36,10 @@ func TestConnectionManager_ConnectAndGet(t *testing.T) {
 	server := newTestServer(t)
 
 	// Create client transport and connection manager
-	clientTP := NewThreadPool(map[string]PoolConfig{"generic": {Workers: 2, QueueSize: 10}})
-	t.Cleanup(clientTP.Shutdown)
+	clientWP := NewWorkerPool(map[PoolName]PoolConfig{PoolGeneric: {Workers: 2, QueueSize: 10}})
+	t.Cleanup(clientWP.Shutdown)
 	clientNode := DiscoveryNode{ID: "client", Name: "client"}
-	clientTransport := NewTcpTransport(clientNode, NewRequestHandlerMap(), NewResponseHandlers(), clientTP)
+	clientTransport := NewTcpTransport(clientNode, NewRequestHandlerMap(), NewResponseHandlers(), clientWP)
 
 	cm := NewConnectionManager(clientTransport, testProfile())
 	t.Cleanup(func() { cm.Close() })
@@ -64,10 +64,10 @@ func TestConnectionManager_ConnectAndGet(t *testing.T) {
 }
 
 func TestConnectionManager_GetConnection_NotConnected(t *testing.T) {
-	clientTP := NewThreadPool(map[string]PoolConfig{"generic": {Workers: 2, QueueSize: 10}})
-	t.Cleanup(clientTP.Shutdown)
+	clientWP := NewWorkerPool(map[PoolName]PoolConfig{PoolGeneric: {Workers: 2, QueueSize: 10}})
+	t.Cleanup(clientWP.Shutdown)
 	clientNode := DiscoveryNode{ID: "client", Name: "client"}
-	clientTransport := NewTcpTransport(clientNode, NewRequestHandlerMap(), NewResponseHandlers(), clientTP)
+	clientTransport := NewTcpTransport(clientNode, NewRequestHandlerMap(), NewResponseHandlers(), clientWP)
 
 	cm := NewConnectionManager(clientTransport, testProfile())
 	t.Cleanup(func() { cm.Close() })
@@ -91,10 +91,10 @@ func TestConnectionManager_Disconnect(t *testing.T) {
 	server := newTestServer(t)
 
 	// Create client transport and connection manager
-	clientTP := NewThreadPool(map[string]PoolConfig{"generic": {Workers: 2, QueueSize: 10}})
-	t.Cleanup(clientTP.Shutdown)
+	clientWP := NewWorkerPool(map[PoolName]PoolConfig{PoolGeneric: {Workers: 2, QueueSize: 10}})
+	t.Cleanup(clientWP.Shutdown)
 	clientNode := DiscoveryNode{ID: "client", Name: "client"}
-	clientTransport := NewTcpTransport(clientNode, NewRequestHandlerMap(), NewResponseHandlers(), clientTP)
+	clientTransport := NewTcpTransport(clientNode, NewRequestHandlerMap(), NewResponseHandlers(), clientWP)
 
 	cm := NewConnectionManager(clientTransport, testProfile())
 	t.Cleanup(func() { cm.Close() })
@@ -130,10 +130,10 @@ func TestConnectionManager_ConnectedNodes(t *testing.T) {
 	server := newTestServer(t)
 
 	// Create client transport and connection manager
-	clientTP := NewThreadPool(map[string]PoolConfig{"generic": {Workers: 2, QueueSize: 10}})
-	t.Cleanup(clientTP.Shutdown)
+	clientWP := NewWorkerPool(map[PoolName]PoolConfig{PoolGeneric: {Workers: 2, QueueSize: 10}})
+	t.Cleanup(clientWP.Shutdown)
 	clientNode := DiscoveryNode{ID: "client", Name: "client"}
-	clientTransport := NewTcpTransport(clientNode, NewRequestHandlerMap(), NewResponseHandlers(), clientTP)
+	clientTransport := NewTcpTransport(clientNode, NewRequestHandlerMap(), NewResponseHandlers(), clientWP)
 
 	cm := NewConnectionManager(clientTransport, testProfile())
 	t.Cleanup(func() { cm.Close() })

--- a/server/transport/connection_manager_test.go
+++ b/server/transport/connection_manager_test.go
@@ -1,0 +1,161 @@
+package transport
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func newTestServer(t *testing.T) *TcpTransport {
+	t.Helper()
+	tp := NewThreadPool(map[string]PoolConfig{"generic": {Workers: 2, QueueSize: 10}})
+	t.Cleanup(tp.Shutdown)
+	rh := NewRequestHandlerMap()
+	resph := NewResponseHandlers()
+	node := DiscoveryNode{ID: "server", Name: "server"}
+	transport := NewTcpTransport(node, rh, resph, tp)
+	addr, err := transport.Start("127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { transport.Stop() })
+	// Update node address
+	transport.localNode.Address = addr
+	return transport
+}
+
+func testProfile() ConnectionProfile {
+	return ConnectionProfile{
+		ConnPerType:      map[ConnectionType]int{ConnTypeREG: 1},
+		ConnectTimeout:   5 * time.Second,
+		HandshakeTimeout: 5 * time.Second,
+	}
+}
+
+func TestConnectionManager_ConnectAndGet(t *testing.T) {
+	server := newTestServer(t)
+
+	// Create client transport and connection manager
+	clientTP := NewThreadPool(map[string]PoolConfig{"generic": {Workers: 2, QueueSize: 10}})
+	t.Cleanup(clientTP.Shutdown)
+	clientNode := DiscoveryNode{ID: "client", Name: "client"}
+	clientTransport := NewTcpTransport(clientNode, NewRequestHandlerMap(), NewResponseHandlers(), clientTP)
+
+	cm := NewConnectionManager(clientTransport, testProfile())
+	t.Cleanup(func() { cm.Close() })
+
+	// Connect to server
+	err := cm.Connect(server.localNode)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+
+	// GetConnection should succeed
+	conn, err := cm.GetConnection(server.localNode.ID)
+	if err != nil {
+		t.Fatalf("GetConnection failed: %v", err)
+	}
+	if conn == nil {
+		t.Fatal("GetConnection returned nil connection")
+	}
+	if conn.node.ID != server.localNode.ID {
+		t.Errorf("connection node ID = %q, want %q", conn.node.ID, server.localNode.ID)
+	}
+}
+
+func TestConnectionManager_GetConnection_NotConnected(t *testing.T) {
+	clientTP := NewThreadPool(map[string]PoolConfig{"generic": {Workers: 2, QueueSize: 10}})
+	t.Cleanup(clientTP.Shutdown)
+	clientNode := DiscoveryNode{ID: "client", Name: "client"}
+	clientTransport := NewTcpTransport(clientNode, NewRequestHandlerMap(), NewResponseHandlers(), clientTP)
+
+	cm := NewConnectionManager(clientTransport, testProfile())
+	t.Cleanup(func() { cm.Close() })
+
+	// GetConnection for unknown node should return error
+	_, err := cm.GetConnection("unknown-node")
+	if err == nil {
+		t.Fatal("expected error for unknown node, got nil")
+	}
+
+	var notConnectedErr *NodeNotConnectedError
+	if !errors.As(err, &notConnectedErr) {
+		t.Errorf("error type = %T, want *NodeNotConnectedError", err)
+	}
+	if notConnectedErr.NodeID != "unknown-node" {
+		t.Errorf("error NodeID = %q, want %q", notConnectedErr.NodeID, "unknown-node")
+	}
+}
+
+func TestConnectionManager_Disconnect(t *testing.T) {
+	server := newTestServer(t)
+
+	// Create client transport and connection manager
+	clientTP := NewThreadPool(map[string]PoolConfig{"generic": {Workers: 2, QueueSize: 10}})
+	t.Cleanup(clientTP.Shutdown)
+	clientNode := DiscoveryNode{ID: "client", Name: "client"}
+	clientTransport := NewTcpTransport(clientNode, NewRequestHandlerMap(), NewResponseHandlers(), clientTP)
+
+	cm := NewConnectionManager(clientTransport, testProfile())
+	t.Cleanup(func() { cm.Close() })
+
+	// Connect to server
+	err := cm.Connect(server.localNode)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+
+	// GetConnection should succeed
+	_, err = cm.GetConnection(server.localNode.ID)
+	if err != nil {
+		t.Fatalf("GetConnection before disconnect failed: %v", err)
+	}
+
+	// Disconnect
+	cm.DisconnectFromNode(server.localNode.ID)
+
+	// GetConnection should now fail
+	_, err = cm.GetConnection(server.localNode.ID)
+	if err == nil {
+		t.Fatal("expected error after disconnect, got nil")
+	}
+
+	var notConnectedErr *NodeNotConnectedError
+	if !errors.As(err, &notConnectedErr) {
+		t.Errorf("error type after disconnect = %T, want *NodeNotConnectedError", err)
+	}
+}
+
+func TestConnectionManager_ConnectedNodes(t *testing.T) {
+	server := newTestServer(t)
+
+	// Create client transport and connection manager
+	clientTP := NewThreadPool(map[string]PoolConfig{"generic": {Workers: 2, QueueSize: 10}})
+	t.Cleanup(clientTP.Shutdown)
+	clientNode := DiscoveryNode{ID: "client", Name: "client"}
+	clientTransport := NewTcpTransport(clientNode, NewRequestHandlerMap(), NewResponseHandlers(), clientTP)
+
+	cm := NewConnectionManager(clientTransport, testProfile())
+	t.Cleanup(func() { cm.Close() })
+
+	// Initially empty
+	nodes := cm.ConnectedNodes()
+	if len(nodes) != 0 {
+		t.Errorf("initial ConnectedNodes length = %d, want 0", len(nodes))
+	}
+
+	// Connect to server
+	err := cm.Connect(server.localNode)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+
+	// Should have 1 entry
+	nodes = cm.ConnectedNodes()
+	if len(nodes) != 1 {
+		t.Errorf("ConnectedNodes length after connect = %d, want 1", len(nodes))
+	}
+	if len(nodes) > 0 && nodes[0].ID != server.localNode.ID {
+		t.Errorf("ConnectedNodes[0].ID = %q, want %q", nodes[0].ID, server.localNode.ID)
+	}
+}

--- a/server/transport/discovery_node.go
+++ b/server/transport/discovery_node.go
@@ -1,0 +1,9 @@
+package transport
+
+// DiscoveryNode represents a node in the cluster.
+// Minimal definition for the transport layer; will be extended in Phase 2 (discovery).
+type DiscoveryNode struct {
+	ID      string
+	Name    string
+	Address string // host:port for transport
+}

--- a/server/transport/errors.go
+++ b/server/transport/errors.go
@@ -1,0 +1,82 @@
+package transport
+
+import "fmt"
+
+type RemoteTransportError struct {
+	NodeID  string
+	Action  string
+	Message string
+}
+
+func (e *RemoteTransportError) Error() string {
+	return fmt.Sprintf("[%s][%s] %s", e.NodeID, e.Action, e.Message)
+}
+
+func (e *RemoteTransportError) WriteTo(out *StreamOutput) error {
+	if err := out.WriteString(e.NodeID); err != nil {
+		return err
+	}
+	if err := out.WriteString(e.Action); err != nil {
+		return err
+	}
+	return out.WriteString(e.Message)
+}
+
+func ReadRemoteTransportError(in *StreamInput) (*RemoteTransportError, error) {
+	nodeID, err := in.ReadString()
+	if err != nil {
+		return nil, err
+	}
+	action, err := in.ReadString()
+	if err != nil {
+		return nil, err
+	}
+	msg, err := in.ReadString()
+	if err != nil {
+		return nil, err
+	}
+	return &RemoteTransportError{NodeID: nodeID, Action: action, Message: msg}, nil
+}
+
+type NodeNotConnectedError struct {
+	NodeID string
+}
+
+func (e *NodeNotConnectedError) Error() string {
+	return fmt.Sprintf("node not connected [%s]", e.NodeID)
+}
+
+type ConnectTransportError struct {
+	NodeID string
+	Cause  error
+}
+
+func (e *ConnectTransportError) Error() string {
+	return fmt.Sprintf("failed to connect to node [%s]: %v", e.NodeID, e.Cause)
+}
+
+func (e *ConnectTransportError) Unwrap() error {
+	return e.Cause
+}
+
+type SendRequestError struct {
+	Action string
+	Cause  error
+}
+
+func (e *SendRequestError) Error() string {
+	return fmt.Sprintf("failed to send [%s]: %v", e.Action, e.Cause)
+}
+
+func (e *SendRequestError) Unwrap() error {
+	return e.Cause
+}
+
+type ResponseTimeoutError struct {
+	Action    string
+	RequestID int64
+}
+
+func (e *ResponseTimeoutError) Error() string {
+	return fmt.Sprintf("response timeout [%s] requestID=%d", e.Action, e.RequestID)
+}

--- a/server/transport/executor.go
+++ b/server/transport/executor.go
@@ -1,0 +1,99 @@
+package transport
+
+import (
+	"errors"
+	"sync"
+)
+
+var ErrRejected = errors.New("executor rejected: queue full")
+
+// Executor runs tasks in a controlled concurrency context.
+type Executor interface {
+	Execute(task func()) error
+	Shutdown()
+}
+
+// DirectExecutor runs tasks inline on the calling goroutine.
+type DirectExecutor struct{}
+
+func (d *DirectExecutor) Execute(task func()) error {
+	task()
+	return nil
+}
+
+func (d *DirectExecutor) Shutdown() {}
+
+// BoundedExecutor runs tasks on a fixed pool of worker goroutines
+// with a bounded queue for backpressure.
+type BoundedExecutor struct {
+	queue chan func()
+	wg    sync.WaitGroup
+}
+
+func NewBoundedExecutor(workers, queueSize int) *BoundedExecutor {
+	e := &BoundedExecutor{
+		queue: make(chan func(), queueSize),
+	}
+	e.wg.Add(workers)
+	for range workers {
+		go func() {
+			defer e.wg.Done()
+			for task := range e.queue {
+				task()
+			}
+		}()
+	}
+	return e
+}
+
+func (e *BoundedExecutor) Execute(task func()) error {
+	select {
+	case e.queue <- task:
+		return nil
+	default:
+		return ErrRejected
+	}
+}
+
+func (e *BoundedExecutor) Shutdown() {
+	close(e.queue)
+	e.wg.Wait()
+}
+
+// PoolConfig configures a named executor pool.
+// Workers == 0 means DirectExecutor (inline).
+type PoolConfig struct {
+	Workers   int
+	QueueSize int
+}
+
+// ThreadPool manages named executor pools.
+type ThreadPool struct {
+	pools map[string]Executor
+}
+
+func NewThreadPool(configs map[string]PoolConfig) *ThreadPool {
+	pools := make(map[string]Executor, len(configs))
+	for name, cfg := range configs {
+		if cfg.Workers == 0 {
+			pools[name] = &DirectExecutor{}
+		} else {
+			pools[name] = NewBoundedExecutor(cfg.Workers, cfg.QueueSize)
+		}
+	}
+	return &ThreadPool{pools: pools}
+}
+
+// Get returns the named executor, falling back to "generic" if not found.
+func (tp *ThreadPool) Get(name string) Executor {
+	if e, ok := tp.pools[name]; ok {
+		return e
+	}
+	return tp.pools["generic"]
+}
+
+func (tp *ThreadPool) Shutdown() {
+	for _, e := range tp.pools {
+		e.Shutdown()
+	}
+}

--- a/server/transport/executor.go
+++ b/server/transport/executor.go
@@ -5,95 +5,81 @@ import (
 	"sync"
 )
 
-var ErrRejected = errors.New("executor rejected: queue full")
+var ErrRejected = errors.New("worker pool rejected: queue full")
 
-// Executor runs tasks in a controlled concurrency context.
-type Executor interface {
-	Execute(task func()) error
-	Shutdown()
+// PoolName identifies a named worker pool.
+type PoolName string
+
+const (
+	PoolGeneric         PoolName = "generic"
+	PoolSearch          PoolName = "search"
+	PoolIndex           PoolName = "index"
+	PoolTransportWorker PoolName = "transport_worker"
+	PoolClusterState    PoolName = "cluster_state"
+)
+
+// PoolConfig configures a named worker pool.
+// Workers == 0 means tasks run inline on the calling goroutine.
+type PoolConfig struct {
+	Workers   int
+	QueueSize int
 }
 
-// DirectExecutor runs tasks inline on the calling goroutine.
-type DirectExecutor struct{}
-
-func (d *DirectExecutor) Execute(task func()) error {
-	task()
-	return nil
+// WorkerPool manages named pools of worker goroutines backed by channels.
+type WorkerPool struct {
+	queues map[PoolName]chan func()
+	wg     sync.WaitGroup
 }
 
-func (d *DirectExecutor) Shutdown() {}
-
-// BoundedExecutor runs tasks on a fixed pool of worker goroutines
-// with a bounded queue for backpressure.
-type BoundedExecutor struct {
-	queue chan func()
-	wg    sync.WaitGroup
-}
-
-func NewBoundedExecutor(workers, queueSize int) *BoundedExecutor {
-	e := &BoundedExecutor{
-		queue: make(chan func(), queueSize),
+func NewWorkerPool(configs map[PoolName]PoolConfig) *WorkerPool {
+	wp := &WorkerPool{
+		queues: make(map[PoolName]chan func(), len(configs)),
 	}
-	e.wg.Add(workers)
-	for range workers {
-		go func() {
-			defer e.wg.Done()
-			for task := range e.queue {
-				task()
-			}
-		}()
+	for name, cfg := range configs {
+		if cfg.Workers == 0 {
+			wp.queues[name] = nil // nil means run inline
+			continue
+		}
+		ch := make(chan func(), cfg.QueueSize)
+		wp.queues[name] = ch
+		wp.wg.Add(cfg.Workers)
+		for range cfg.Workers {
+			go func() {
+				defer wp.wg.Done()
+				for task := range ch {
+					task()
+				}
+			}()
+		}
 	}
-	return e
+	return wp
 }
 
-func (e *BoundedExecutor) Execute(task func()) error {
+// Submit sends a task to the named pool. Falls back to "generic" if the name
+// is not found. Returns ErrRejected if the queue is full.
+// If the pool is configured with Workers == 0, the task runs inline.
+func (wp *WorkerPool) Submit(name PoolName, task func()) error {
+	ch, ok := wp.queues[name]
+	if !ok {
+		ch = wp.queues[PoolGeneric]
+	}
+	if ch == nil {
+		task()
+		return nil
+	}
 	select {
-	case e.queue <- task:
+	case ch <- task:
 		return nil
 	default:
 		return ErrRejected
 	}
 }
 
-func (e *BoundedExecutor) Shutdown() {
-	close(e.queue)
-	e.wg.Wait()
-}
-
-// PoolConfig configures a named executor pool.
-// Workers == 0 means DirectExecutor (inline).
-type PoolConfig struct {
-	Workers   int
-	QueueSize int
-}
-
-// ThreadPool manages named executor pools.
-type ThreadPool struct {
-	pools map[string]Executor
-}
-
-func NewThreadPool(configs map[string]PoolConfig) *ThreadPool {
-	pools := make(map[string]Executor, len(configs))
-	for name, cfg := range configs {
-		if cfg.Workers == 0 {
-			pools[name] = &DirectExecutor{}
-		} else {
-			pools[name] = NewBoundedExecutor(cfg.Workers, cfg.QueueSize)
+func (wp *WorkerPool) Shutdown() {
+	for _, ch := range wp.queues {
+		if ch != nil {
+			close(ch)
 		}
 	}
-	return &ThreadPool{pools: pools}
-}
-
-// Get returns the named executor, falling back to "generic" if not found.
-func (tp *ThreadPool) Get(name string) Executor {
-	if e, ok := tp.pools[name]; ok {
-		return e
-	}
-	return tp.pools["generic"]
-}
-
-func (tp *ThreadPool) Shutdown() {
-	for _, e := range tp.pools {
-		e.Shutdown()
-	}
+	wp.wg.Wait()
 }

--- a/server/transport/executor_test.go
+++ b/server/transport/executor_test.go
@@ -7,32 +7,37 @@ import (
 	"time"
 )
 
-func TestDirectExecutor(t *testing.T) {
-	exec := &DirectExecutor{}
+func TestWorkerPool_InlineExecution(t *testing.T) {
+	wp := NewWorkerPool(map[PoolName]PoolConfig{
+		PoolGeneric: {Workers: 0},
+	})
+	defer wp.Shutdown()
+
 	var executed bool
-	err := exec.Execute(func() {
+	err := wp.Submit(PoolGeneric, func() {
 		executed = true
 	})
 	if err != nil {
-		t.Fatalf("DirectExecutor.Execute() returned error: %v", err)
+		t.Fatalf("Submit() returned error: %v", err)
 	}
 	if !executed {
-		t.Fatal("DirectExecutor did not run task inline")
+		t.Fatal("inline pool did not run task synchronously")
 	}
-	exec.Shutdown() // should be no-op
 }
 
-func TestBoundedExecutor_ExecutesTasks(t *testing.T) {
-	exec := NewBoundedExecutor(2, 10)
-	defer exec.Shutdown()
+func TestWorkerPool_ExecutesTasks(t *testing.T) {
+	wp := NewWorkerPool(map[PoolName]PoolConfig{
+		PoolGeneric: {Workers: 2, QueueSize: 10},
+	})
+	defer wp.Shutdown()
 
 	var count atomic.Int32
 	for range 5 {
-		err := exec.Execute(func() {
+		err := wp.Submit(PoolGeneric, func() {
 			count.Add(1)
 		})
 		if err != nil {
-			t.Fatalf("Execute() returned error: %v", err)
+			t.Fatalf("Submit() returned error: %v", err)
 		}
 	}
 
@@ -43,32 +48,34 @@ func TestBoundedExecutor_ExecutesTasks(t *testing.T) {
 	}
 }
 
-func TestBoundedExecutor_Backpressure(t *testing.T) {
-	exec := NewBoundedExecutor(1, 1)
-	defer exec.Shutdown()
+func TestWorkerPool_Backpressure(t *testing.T) {
+	wp := NewWorkerPool(map[PoolName]PoolConfig{
+		PoolGeneric: {Workers: 1, QueueSize: 1},
+	})
+	defer wp.Shutdown()
 
 	// Block the worker
 	unblock := make(chan struct{})
 	workerStarted := make(chan struct{})
-	err := exec.Execute(func() {
+	err := wp.Submit(PoolGeneric, func() {
 		close(workerStarted)
 		<-unblock
 	})
 	if err != nil {
-		t.Fatalf("First Execute() failed: %v", err)
+		t.Fatalf("First Submit() failed: %v", err)
 	}
 
 	// Wait for worker to start
 	<-workerStarted
 
 	// Fill the queue
-	err = exec.Execute(func() {})
+	err = wp.Submit(PoolGeneric, func() {})
 	if err != nil {
-		t.Fatalf("Second Execute() failed: %v", err)
+		t.Fatalf("Second Submit() failed: %v", err)
 	}
 
 	// Third task should be rejected
-	err = exec.Execute(func() {})
+	err = wp.Submit(PoolGeneric, func() {})
 	if err != ErrRejected {
 		t.Errorf("Expected ErrRejected, got %v", err)
 	}
@@ -76,87 +83,73 @@ func TestBoundedExecutor_Backpressure(t *testing.T) {
 	close(unblock)
 }
 
-func TestBoundedExecutor_ShutdownDrains(t *testing.T) {
-	exec := NewBoundedExecutor(2, 10)
+func TestWorkerPool_ShutdownDrains(t *testing.T) {
+	wp := NewWorkerPool(map[PoolName]PoolConfig{
+		PoolGeneric: {Workers: 2, QueueSize: 10},
+	})
 
 	var count atomic.Int32
 	for range 10 {
-		exec.Execute(func() {
+		wp.Submit(PoolGeneric, func() {
 			time.Sleep(10 * time.Millisecond)
 			count.Add(1)
 		})
 	}
 
-	exec.Shutdown()
+	wp.Shutdown()
 	if got := count.Load(); got != 10 {
 		t.Errorf("Expected all 10 tasks to complete after Shutdown(), got %d", got)
 	}
 }
 
-func TestThreadPool_Get(t *testing.T) {
-	tp := NewThreadPool(map[string]PoolConfig{
-		"generic": {Workers: 2, QueueSize: 10},
-		"search":  {Workers: 4, QueueSize: 20},
+func TestWorkerPool_NamedPools(t *testing.T) {
+	wp := NewWorkerPool(map[PoolName]PoolConfig{
+		PoolGeneric: {Workers: 2, QueueSize: 10},
+		PoolSearch:  {Workers: 4, QueueSize: 20},
 	})
-	defer tp.Shutdown()
-
-	searchExec := tp.Get("search")
-	if searchExec == nil {
-		t.Fatal("Expected search executor to exist")
-	}
+	defer wp.Shutdown()
 
 	var wg sync.WaitGroup
 	wg.Add(1)
-	err := searchExec.Execute(func() {
+	err := wp.Submit(PoolSearch, func() {
 		wg.Done()
 	})
 	if err != nil {
-		t.Fatalf("Execute() on search pool failed: %v", err)
+		t.Fatalf("Submit() on search pool failed: %v", err)
 	}
 	wg.Wait()
 }
 
-func TestThreadPool_GetFallback(t *testing.T) {
-	tp := NewThreadPool(map[string]PoolConfig{
-		"generic": {Workers: 2, QueueSize: 10},
+func TestWorkerPool_FallbackToGeneric(t *testing.T) {
+	wp := NewWorkerPool(map[PoolName]PoolConfig{
+		PoolGeneric: {Workers: 2, QueueSize: 10},
 	})
-	defer tp.Shutdown()
-
-	exec := tp.Get("nonexistent")
-	if exec == nil {
-		t.Fatal("Expected fallback to generic executor")
-	}
+	defer wp.Shutdown()
 
 	var wg sync.WaitGroup
 	wg.Add(1)
-	err := exec.Execute(func() {
+	err := wp.Submit("nonexistent", func() {
 		wg.Done()
 	})
 	if err != nil {
-		t.Fatalf("Execute() on fallback pool failed: %v", err)
+		t.Fatalf("Submit() on fallback pool failed: %v", err)
 	}
 	wg.Wait()
 }
 
-func TestThreadPool_TransportWorkerInline(t *testing.T) {
-	tp := NewThreadPool(map[string]PoolConfig{
-		"generic":          {Workers: 2, QueueSize: 10},
-		"transport_worker": {Workers: 0, QueueSize: 0},
+func TestWorkerPool_InlinePool(t *testing.T) {
+	wp := NewWorkerPool(map[PoolName]PoolConfig{
+		PoolGeneric:         {Workers: 2, QueueSize: 10},
+		PoolTransportWorker: {Workers: 0},
 	})
-	defer tp.Shutdown()
-
-	exec := tp.Get("transport_worker")
-	_, isDirectExec := exec.(*DirectExecutor)
-	if !isDirectExec {
-		t.Fatal("Expected transport_worker pool to be a DirectExecutor")
-	}
+	defer wp.Shutdown()
 
 	var executed bool
-	err := exec.Execute(func() {
+	err := wp.Submit(PoolTransportWorker, func() {
 		executed = true
 	})
 	if err != nil {
-		t.Fatalf("Execute() on transport_worker pool failed: %v", err)
+		t.Fatalf("Submit() on transport_worker pool failed: %v", err)
 	}
 	if !executed {
 		t.Fatal("transport_worker pool did not run task inline")

--- a/server/transport/executor_test.go
+++ b/server/transport/executor_test.go
@@ -1,0 +1,164 @@
+package transport
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestDirectExecutor(t *testing.T) {
+	exec := &DirectExecutor{}
+	var executed bool
+	err := exec.Execute(func() {
+		executed = true
+	})
+	if err != nil {
+		t.Fatalf("DirectExecutor.Execute() returned error: %v", err)
+	}
+	if !executed {
+		t.Fatal("DirectExecutor did not run task inline")
+	}
+	exec.Shutdown() // should be no-op
+}
+
+func TestBoundedExecutor_ExecutesTasks(t *testing.T) {
+	exec := NewBoundedExecutor(2, 10)
+	defer exec.Shutdown()
+
+	var count atomic.Int32
+	for range 5 {
+		err := exec.Execute(func() {
+			count.Add(1)
+		})
+		if err != nil {
+			t.Fatalf("Execute() returned error: %v", err)
+		}
+	}
+
+	// Wait for tasks to complete
+	time.Sleep(50 * time.Millisecond)
+	if got := count.Load(); got != 5 {
+		t.Errorf("Expected 5 tasks to run, got %d", got)
+	}
+}
+
+func TestBoundedExecutor_Backpressure(t *testing.T) {
+	exec := NewBoundedExecutor(1, 1)
+	defer exec.Shutdown()
+
+	// Block the worker
+	unblock := make(chan struct{})
+	workerStarted := make(chan struct{})
+	err := exec.Execute(func() {
+		close(workerStarted)
+		<-unblock
+	})
+	if err != nil {
+		t.Fatalf("First Execute() failed: %v", err)
+	}
+
+	// Wait for worker to start
+	<-workerStarted
+
+	// Fill the queue
+	err = exec.Execute(func() {})
+	if err != nil {
+		t.Fatalf("Second Execute() failed: %v", err)
+	}
+
+	// Third task should be rejected
+	err = exec.Execute(func() {})
+	if err != ErrRejected {
+		t.Errorf("Expected ErrRejected, got %v", err)
+	}
+
+	close(unblock)
+}
+
+func TestBoundedExecutor_ShutdownDrains(t *testing.T) {
+	exec := NewBoundedExecutor(2, 10)
+
+	var count atomic.Int32
+	for range 10 {
+		exec.Execute(func() {
+			time.Sleep(10 * time.Millisecond)
+			count.Add(1)
+		})
+	}
+
+	exec.Shutdown()
+	if got := count.Load(); got != 10 {
+		t.Errorf("Expected all 10 tasks to complete after Shutdown(), got %d", got)
+	}
+}
+
+func TestThreadPool_Get(t *testing.T) {
+	tp := NewThreadPool(map[string]PoolConfig{
+		"generic": {Workers: 2, QueueSize: 10},
+		"search":  {Workers: 4, QueueSize: 20},
+	})
+	defer tp.Shutdown()
+
+	searchExec := tp.Get("search")
+	if searchExec == nil {
+		t.Fatal("Expected search executor to exist")
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	err := searchExec.Execute(func() {
+		wg.Done()
+	})
+	if err != nil {
+		t.Fatalf("Execute() on search pool failed: %v", err)
+	}
+	wg.Wait()
+}
+
+func TestThreadPool_GetFallback(t *testing.T) {
+	tp := NewThreadPool(map[string]PoolConfig{
+		"generic": {Workers: 2, QueueSize: 10},
+	})
+	defer tp.Shutdown()
+
+	exec := tp.Get("nonexistent")
+	if exec == nil {
+		t.Fatal("Expected fallback to generic executor")
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	err := exec.Execute(func() {
+		wg.Done()
+	})
+	if err != nil {
+		t.Fatalf("Execute() on fallback pool failed: %v", err)
+	}
+	wg.Wait()
+}
+
+func TestThreadPool_TransportWorkerInline(t *testing.T) {
+	tp := NewThreadPool(map[string]PoolConfig{
+		"generic":          {Workers: 2, QueueSize: 10},
+		"transport_worker": {Workers: 0, QueueSize: 0},
+	})
+	defer tp.Shutdown()
+
+	exec := tp.Get("transport_worker")
+	_, isDirectExec := exec.(*DirectExecutor)
+	if !isDirectExec {
+		t.Fatal("Expected transport_worker pool to be a DirectExecutor")
+	}
+
+	var executed bool
+	err := exec.Execute(func() {
+		executed = true
+	})
+	if err != nil {
+		t.Fatalf("Execute() on transport_worker pool failed: %v", err)
+	}
+	if !executed {
+		t.Fatal("transport_worker pool did not run task inline")
+	}
+}

--- a/server/transport/handler.go
+++ b/server/transport/handler.go
@@ -4,7 +4,34 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"sync"
 )
+
+// maxPoolableBufferSize is the cap above which buffers are not returned to the
+// pool, preventing a single large request/response from permanently inflating
+// pooled memory.
+const maxPoolableBufferSize = 64 * 1024 // 64 KiB
+
+var bufferPool = sync.Pool{
+	New: func() any {
+		return new(bytes.Buffer)
+	},
+}
+
+// getBuffer retrieves a reset buffer from the pool.
+func getBuffer() *bytes.Buffer {
+	buf := bufferPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	return buf
+}
+
+// putBuffer returns buf to the pool if its capacity is within the limit.
+func putBuffer(buf *bytes.Buffer) {
+	if buf.Cap() > maxPoolableBufferSize {
+		return // let GC reclaim oversized buffers
+	}
+	bufferPool.Put(buf)
+}
 
 const handshakeAction = "internal:transport/handshake"
 
@@ -17,8 +44,10 @@ func NewOutboundHandler() *OutboundHandler {
 
 // SendRequest writes a complete request message (header + payload) to w.
 func (oh *OutboundHandler) SendRequest(w io.Writer, requestID int64, action string, request Writeable) error {
-	var payload bytes.Buffer
-	out := NewStreamOutput(&payload)
+	payload := getBuffer()
+	defer putBuffer(payload)
+
+	out := NewStreamOutput(payload)
 	if err := request.WriteTo(out); err != nil {
 		return fmt.Errorf("serialize request payload: %w", err)
 	}
@@ -31,45 +60,12 @@ func (oh *OutboundHandler) SendRequest(w io.Writer, requestID int64, action stri
 	return writeMessageWithPayload(w, h, payload.Bytes())
 }
 
-// SendResponse writes a complete response message to w.
-func (oh *OutboundHandler) SendResponse(w io.Writer, requestID int64, response Writeable) error {
-	var payload bytes.Buffer
-	out := NewStreamOutput(&payload)
-	if err := response.WriteTo(out); err != nil {
-		return fmt.Errorf("serialize response payload: %w", err)
-	}
-
-	h := &Header{
-		RequestID: requestID,
-		Status:    StatusFlags(0),
-	}
-	return writeMessageWithPayload(w, h, payload.Bytes())
-}
-
-// SendErrorResponse writes an error response message to w.
-func (oh *OutboundHandler) SendErrorResponse(w io.Writer, requestID int64, nodeID string, action string, errMsg error) error {
-	rte := &RemoteTransportError{
-		NodeID:  nodeID,
-		Action:  action,
-		Message: errMsg.Error(),
-	}
-	var payload bytes.Buffer
-	out := NewStreamOutput(&payload)
-	if err := rte.WriteTo(out); err != nil {
-		return fmt.Errorf("serialize error payload: %w", err)
-	}
-
-	h := &Header{
-		RequestID: requestID,
-		Status:    StatusFlags(0).WithError(true),
-	}
-	return writeMessageWithPayload(w, h, payload.Bytes())
-}
-
 // SendHandshakeRequest writes a handshake request message to w.
 func (oh *OutboundHandler) SendHandshakeRequest(w io.Writer, requestID int64, req *HandshakeRequest) error {
-	var payload bytes.Buffer
-	out := NewStreamOutput(&payload)
+	payload := getBuffer()
+	defer putBuffer(payload)
+
+	out := NewStreamOutput(payload)
 	if err := req.WriteTo(out); err != nil {
 		return fmt.Errorf("serialize handshake request: %w", err)
 	}
@@ -84,8 +80,10 @@ func (oh *OutboundHandler) SendHandshakeRequest(w io.Writer, requestID int64, re
 
 // SendHandshakeResponse writes a handshake response message to w.
 func (oh *OutboundHandler) SendHandshakeResponse(w io.Writer, requestID int64, resp *HandshakeResponse) error {
-	var payload bytes.Buffer
-	out := NewStreamOutput(&payload)
+	payload := getBuffer()
+	defer putBuffer(payload)
+
+	out := NewStreamOutput(payload)
 	if err := resp.WriteTo(out); err != nil {
 		return fmt.Errorf("serialize handshake response: %w", err)
 	}
@@ -101,15 +99,15 @@ func (oh *OutboundHandler) SendHandshakeResponse(w io.Writer, requestID int64, r
 type InboundHandler struct {
 	requestHandlers  *RequestHandlerMap
 	responseHandlers *ResponseHandlers
-	threadPool       *ThreadPool
+	workerPool       *WorkerPool
 	localNodeID      string
 }
 
-func NewInboundHandler(requestHandlers *RequestHandlerMap, responseHandlers *ResponseHandlers, threadPool *ThreadPool, localNodeID string) *InboundHandler {
+func NewInboundHandler(requestHandlers *RequestHandlerMap, responseHandlers *ResponseHandlers, workerPool *WorkerPool, localNodeID string) *InboundHandler {
 	return &InboundHandler{
 		requestHandlers:  requestHandlers,
 		responseHandlers: responseHandlers,
-		threadPool:       threadPool,
+		workerPool:       workerPool,
 		localNodeID:      localNodeID,
 	}
 }
@@ -163,8 +161,7 @@ func (ih *InboundHandler) handleRequest(si *StreamInput, respWriter io.Writer, h
 
 	channel := NewTcpTransportChannel(h.RequestID, respWriter)
 
-	executor := ih.threadPool.Get(entry.executor)
-	return executor.Execute(func() {
+	return ih.workerPool.Submit(entry.executor, func() {
 		entry.dispatch(si, channel)
 	})
 }
@@ -180,22 +177,11 @@ func (ih *InboundHandler) handleResponse(si *StreamInput, h *Header) error {
 		if err != nil {
 			return fmt.Errorf("read remote transport error: %w", err)
 		}
-		type errorHandler interface {
-			HandleError(*RemoteTransportError)
-		}
-		if eh, ok := ctx.Handler.(errorHandler); ok {
-			eh.HandleError(rte)
-		}
+		ctx.Handler.HandleError(rte)
 		return nil
 	}
 
-	type successHandler interface {
-		ReadAndHandle(*StreamInput) error
-	}
-	if sh, ok := ctx.Handler.(successHandler); ok {
-		return sh.ReadAndHandle(si)
-	}
-	return nil
+	return ctx.Handler.ReadAndHandle(si)
 }
 
 // readPayload reads the payload bytes from r based on the header's payload size.

--- a/server/transport/handler.go
+++ b/server/transport/handler.go
@@ -1,0 +1,210 @@
+package transport
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+)
+
+const handshakeAction = "internal:transport/handshake"
+
+// OutboundHandler serializes and sends transport messages.
+type OutboundHandler struct{}
+
+func NewOutboundHandler() *OutboundHandler {
+	return &OutboundHandler{}
+}
+
+// SendRequest writes a complete request message (header + payload) to w.
+func (oh *OutboundHandler) SendRequest(w io.Writer, requestID int64, action string, request Writeable) error {
+	var payload bytes.Buffer
+	out := NewStreamOutput(&payload)
+	if err := request.WriteTo(out); err != nil {
+		return fmt.Errorf("serialize request payload: %w", err)
+	}
+
+	h := &Header{
+		RequestID: requestID,
+		Status:    StatusFlags(0).WithRequest(true),
+		Action:    action,
+	}
+	return writeMessageWithPayload(w, h, payload.Bytes())
+}
+
+// SendResponse writes a complete response message to w.
+func (oh *OutboundHandler) SendResponse(w io.Writer, requestID int64, response Writeable) error {
+	var payload bytes.Buffer
+	out := NewStreamOutput(&payload)
+	if err := response.WriteTo(out); err != nil {
+		return fmt.Errorf("serialize response payload: %w", err)
+	}
+
+	h := &Header{
+		RequestID: requestID,
+		Status:    StatusFlags(0),
+	}
+	return writeMessageWithPayload(w, h, payload.Bytes())
+}
+
+// SendErrorResponse writes an error response message to w.
+func (oh *OutboundHandler) SendErrorResponse(w io.Writer, requestID int64, nodeID string, action string, errMsg error) error {
+	rte := &RemoteTransportError{
+		NodeID:  nodeID,
+		Action:  action,
+		Message: errMsg.Error(),
+	}
+	var payload bytes.Buffer
+	out := NewStreamOutput(&payload)
+	if err := rte.WriteTo(out); err != nil {
+		return fmt.Errorf("serialize error payload: %w", err)
+	}
+
+	h := &Header{
+		RequestID: requestID,
+		Status:    StatusFlags(0).WithError(true),
+	}
+	return writeMessageWithPayload(w, h, payload.Bytes())
+}
+
+// SendHandshakeRequest writes a handshake request message to w.
+func (oh *OutboundHandler) SendHandshakeRequest(w io.Writer, requestID int64, req *HandshakeRequest) error {
+	var payload bytes.Buffer
+	out := NewStreamOutput(&payload)
+	if err := req.WriteTo(out); err != nil {
+		return fmt.Errorf("serialize handshake request: %w", err)
+	}
+
+	h := &Header{
+		RequestID: requestID,
+		Status:    StatusFlags(0).WithRequest(true).WithHandshake(true),
+		Action:    handshakeAction,
+	}
+	return writeMessageWithPayload(w, h, payload.Bytes())
+}
+
+// SendHandshakeResponse writes a handshake response message to w.
+func (oh *OutboundHandler) SendHandshakeResponse(w io.Writer, requestID int64, resp *HandshakeResponse) error {
+	var payload bytes.Buffer
+	out := NewStreamOutput(&payload)
+	if err := resp.WriteTo(out); err != nil {
+		return fmt.Errorf("serialize handshake response: %w", err)
+	}
+
+	h := &Header{
+		RequestID: requestID,
+		Status:    StatusFlags(0).WithHandshake(true),
+	}
+	return writeMessageWithPayload(w, h, payload.Bytes())
+}
+
+// InboundHandler receives and dispatches incoming messages.
+type InboundHandler struct {
+	requestHandlers  *RequestHandlerMap
+	responseHandlers *ResponseHandlers
+	threadPool       *ThreadPool
+	localNodeID      string
+}
+
+func NewInboundHandler(requestHandlers *RequestHandlerMap, responseHandlers *ResponseHandlers, threadPool *ThreadPool, localNodeID string) *InboundHandler {
+	return &InboundHandler{
+		requestHandlers:  requestHandlers,
+		responseHandlers: responseHandlers,
+		threadPool:       threadPool,
+		localNodeID:      localNodeID,
+	}
+}
+
+// HandleMessage reads one complete message from r and dispatches it.
+func (ih *InboundHandler) HandleMessage(r io.Reader, respWriter io.Writer) error {
+	h, err := ReadHeader(r)
+	if err != nil {
+		return fmt.Errorf("read header: %w", err)
+	}
+
+	payloadBytes, err := readPayload(r, h)
+	if err != nil {
+		return fmt.Errorf("read payload: %w", err)
+	}
+
+	si := NewStreamInput(bytes.NewReader(payloadBytes))
+
+	if h.Status.IsHandshake() && h.Status.IsRequest() {
+		return ih.handleHandshake(si, respWriter, h.RequestID)
+	}
+
+	if h.Status.IsRequest() {
+		return ih.handleRequest(si, respWriter, h)
+	}
+
+	return ih.handleResponse(si, h)
+}
+
+func (ih *InboundHandler) handleHandshake(si *StreamInput, respWriter io.Writer, requestID int64) error {
+	req, err := ReadHandshakeRequest(si)
+	if err != nil {
+		return fmt.Errorf("read handshake request: %w", err)
+	}
+
+	negotiated := NegotiateVersion(CurrentTransportVersion, req.Version)
+	resp := &HandshakeResponse{
+		Version: negotiated,
+		NodeID:  ih.localNodeID,
+	}
+
+	oh := NewOutboundHandler()
+	return oh.SendHandshakeResponse(respWriter, requestID, resp)
+}
+
+func (ih *InboundHandler) handleRequest(si *StreamInput, respWriter io.Writer, h *Header) error {
+	entry := ih.requestHandlers.Get(h.Action)
+	if entry == nil {
+		return fmt.Errorf("no handler registered for action %q", h.Action)
+	}
+
+	channel := NewTcpTransportChannel(h.RequestID, respWriter)
+
+	executor := ih.threadPool.Get(entry.executor)
+	return executor.Execute(func() {
+		entry.dispatch(si, channel)
+	})
+}
+
+func (ih *InboundHandler) handleResponse(si *StreamInput, h *Header) error {
+	ctx := ih.responseHandlers.Remove(h.RequestID)
+	if ctx == nil {
+		return fmt.Errorf("no response handler for requestID %d", h.RequestID)
+	}
+
+	if h.Status.IsError() {
+		rte, err := ReadRemoteTransportError(si)
+		if err != nil {
+			return fmt.Errorf("read remote transport error: %w", err)
+		}
+		type errorHandler interface {
+			HandleError(*RemoteTransportError)
+		}
+		if eh, ok := ctx.Handler.(errorHandler); ok {
+			eh.HandleError(rte)
+		}
+		return nil
+	}
+
+	type successHandler interface {
+		ReadAndHandle(*StreamInput) error
+	}
+	if sh, ok := ctx.Handler.(successHandler); ok {
+		return sh.ReadAndHandle(si)
+	}
+	return nil
+}
+
+// readPayload reads the payload bytes from r based on the header's payload size.
+func readPayload(r io.Reader, h *Header) ([]byte, error) {
+	size := h.PayloadSize()
+	if size <= 0 {
+		return nil, nil
+	}
+	buf := make([]byte, size)
+	_, err := io.ReadFull(r, buf)
+	return buf, err
+}

--- a/server/transport/handler_test.go
+++ b/server/transport/handler_test.go
@@ -42,45 +42,24 @@ func TestOutboundHandler_SendRequest(t *testing.T) {
 	}
 }
 
-func TestOutboundHandler_SendResponse(t *testing.T) {
-	var buf bytes.Buffer
-	oh := NewOutboundHandler()
-
-	resp := &testResponse{Result: "ok"}
-	if err := oh.SendResponse(&buf, 42, resp); err != nil {
-		t.Fatalf("SendResponse failed: %v", err)
-	}
-
-	h, err := ReadHeader(&buf)
-	if err != nil {
-		t.Fatalf("ReadHeader failed: %v", err)
-	}
-	if h.RequestID != 42 {
-		t.Errorf("RequestID = %d, want 42", h.RequestID)
-	}
-	if h.Status.IsRequest() {
-		t.Error("expected IsRequest=false")
-	}
-}
-
 func TestInboundHandler_DispatchRequest(t *testing.T) {
 	handlers := NewRequestHandlerMap()
 	done := make(chan *testRequest, 1)
 
-	RegisterHandler(handlers, "test:echo", "generic", readTestRequest,
+	registerHandler(handlers, "test:echo", PoolGeneric, readTestRequest,
 		func(req *testRequest, ch TransportChannel) error {
 			done <- req
 			return ch.SendResponse(&testResponse{Result: "echo:" + req.Value})
 		},
 	)
 
-	tp := NewThreadPool(map[string]PoolConfig{
-		"generic": {Workers: 0}, // DirectExecutor for synchronous dispatch
+	wp := NewWorkerPool(map[PoolName]PoolConfig{
+		PoolGeneric: {Workers: 0}, // inline for synchronous dispatch
 	})
-	defer tp.Shutdown()
+	defer wp.Shutdown()
 
 	rh := NewResponseHandlers()
-	ih := NewInboundHandler(handlers, rh, tp, "test-node")
+	ih := NewInboundHandler(handlers, rh, wp, "test-node")
 
 	// Write a request message using OutboundHandler
 	var msgBuf bytes.Buffer

--- a/server/transport/handler_test.go
+++ b/server/transport/handler_test.go
@@ -1,0 +1,137 @@
+package transport
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+type testRequest struct{ Value string }
+
+func (r *testRequest) WriteTo(out *StreamOutput) error { return out.WriteString(r.Value) }
+func readTestRequest(in *StreamInput) (*testRequest, error) {
+	v, err := in.ReadString()
+	return &testRequest{Value: v}, err
+}
+
+type testResponse struct{ Result string }
+
+func (r *testResponse) WriteTo(out *StreamOutput) error { return out.WriteString(r.Result) }
+
+func TestOutboundHandler_SendRequest(t *testing.T) {
+	var buf bytes.Buffer
+	oh := NewOutboundHandler()
+
+	req := &testRequest{Value: "hello"}
+	if err := oh.SendRequest(&buf, 42, "test:action", req); err != nil {
+		t.Fatalf("SendRequest failed: %v", err)
+	}
+
+	h, err := ReadHeader(&buf)
+	if err != nil {
+		t.Fatalf("ReadHeader failed: %v", err)
+	}
+	if h.RequestID != 42 {
+		t.Errorf("RequestID = %d, want 42", h.RequestID)
+	}
+	if !h.Status.IsRequest() {
+		t.Error("expected IsRequest=true")
+	}
+	if h.Action != "test:action" {
+		t.Errorf("Action = %q, want %q", h.Action, "test:action")
+	}
+}
+
+func TestOutboundHandler_SendResponse(t *testing.T) {
+	var buf bytes.Buffer
+	oh := NewOutboundHandler()
+
+	resp := &testResponse{Result: "ok"}
+	if err := oh.SendResponse(&buf, 42, resp); err != nil {
+		t.Fatalf("SendResponse failed: %v", err)
+	}
+
+	h, err := ReadHeader(&buf)
+	if err != nil {
+		t.Fatalf("ReadHeader failed: %v", err)
+	}
+	if h.RequestID != 42 {
+		t.Errorf("RequestID = %d, want 42", h.RequestID)
+	}
+	if h.Status.IsRequest() {
+		t.Error("expected IsRequest=false")
+	}
+}
+
+func TestInboundHandler_DispatchRequest(t *testing.T) {
+	handlers := NewRequestHandlerMap()
+	done := make(chan *testRequest, 1)
+
+	RegisterHandler(handlers, "test:echo", "generic", readTestRequest,
+		func(req *testRequest, ch TransportChannel) error {
+			done <- req
+			return ch.SendResponse(&testResponse{Result: "echo:" + req.Value})
+		},
+	)
+
+	tp := NewThreadPool(map[string]PoolConfig{
+		"generic": {Workers: 0}, // DirectExecutor for synchronous dispatch
+	})
+	defer tp.Shutdown()
+
+	rh := NewResponseHandlers()
+	ih := NewInboundHandler(handlers, rh, tp, "test-node")
+
+	// Write a request message using OutboundHandler
+	var msgBuf bytes.Buffer
+	oh := NewOutboundHandler()
+	if err := oh.SendRequest(&msgBuf, 99, "test:echo", &testRequest{Value: "world"}); err != nil {
+		t.Fatalf("SendRequest failed: %v", err)
+	}
+
+	// HandleMessage dispatches the request
+	var respBuf bytes.Buffer
+	if err := ih.HandleMessage(&msgBuf, &respBuf); err != nil {
+		t.Fatalf("HandleMessage failed: %v", err)
+	}
+
+	// Wait for the handler to be called
+	select {
+	case req := <-done:
+		if req.Value != "world" {
+			t.Errorf("request Value = %q, want %q", req.Value, "world")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for handler dispatch")
+	}
+
+	// Verify the response was written
+	if respBuf.Len() == 0 {
+		t.Fatal("expected response to be written to respWriter")
+	}
+
+	respH, err := ReadHeader(&respBuf)
+	if err != nil {
+		t.Fatalf("ReadHeader on response failed: %v", err)
+	}
+	if respH.RequestID != 99 {
+		t.Errorf("response RequestID = %d, want 99", respH.RequestID)
+	}
+	if respH.Status.IsRequest() {
+		t.Error("expected response IsRequest=false")
+	}
+
+	// Read the response payload
+	payloadBytes, err := readPayload(&respBuf, respH)
+	if err != nil {
+		t.Fatalf("readPayload failed: %v", err)
+	}
+	si := NewStreamInput(bytes.NewReader(payloadBytes))
+	result, err := si.ReadString()
+	if err != nil {
+		t.Fatalf("ReadString failed: %v", err)
+	}
+	if result != "echo:world" {
+		t.Errorf("response Result = %q, want %q", result, "echo:world")
+	}
+}

--- a/server/transport/handshake.go
+++ b/server/transport/handshake.go
@@ -1,0 +1,54 @@
+package transport
+
+// TransportVersion is the protocol version for wire compatibility.
+const CurrentTransportVersion int32 = 1
+
+// HandshakeRequest is sent when opening a new connection.
+type HandshakeRequest struct {
+	Version int32
+}
+
+func (r *HandshakeRequest) WriteTo(out *StreamOutput) error {
+	return out.WriteVInt(r.Version)
+}
+
+func ReadHandshakeRequest(in *StreamInput) (*HandshakeRequest, error) {
+	v, err := in.ReadVInt()
+	if err != nil {
+		return nil, err
+	}
+	return &HandshakeRequest{Version: v}, nil
+}
+
+// HandshakeResponse is the reply to a HandshakeRequest.
+type HandshakeResponse struct {
+	Version int32
+	NodeID  string
+}
+
+func (r *HandshakeResponse) WriteTo(out *StreamOutput) error {
+	if err := out.WriteVInt(r.Version); err != nil {
+		return err
+	}
+	return out.WriteString(r.NodeID)
+}
+
+func ReadHandshakeResponse(in *StreamInput) (*HandshakeResponse, error) {
+	v, err := in.ReadVInt()
+	if err != nil {
+		return nil, err
+	}
+	nodeID, err := in.ReadString()
+	if err != nil {
+		return nil, err
+	}
+	return &HandshakeResponse{Version: v, NodeID: nodeID}, nil
+}
+
+// NegotiateVersion returns the minimum of two versions.
+func NegotiateVersion(local, remote int32) int32 {
+	if local < remote {
+		return local
+	}
+	return remote
+}

--- a/server/transport/handshake_test.go
+++ b/server/transport/handshake_test.go
@@ -1,0 +1,78 @@
+package transport
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestHandshakeRequest_Roundtrip(t *testing.T) {
+	// Write version=1
+	var buf bytes.Buffer
+	out := NewStreamOutput(&buf)
+
+	req := &HandshakeRequest{Version: 1}
+	if err := req.WriteTo(out); err != nil {
+		t.Fatalf("WriteTo failed: %v", err)
+	}
+
+	// Read back
+	in := NewStreamInput(&buf)
+	gotReq, err := ReadHandshakeRequest(in)
+	if err != nil {
+		t.Fatalf("ReadHandshakeRequest failed: %v", err)
+	}
+
+	// Verify
+	if gotReq.Version != 1 {
+		t.Errorf("expected version 1, got %d", gotReq.Version)
+	}
+}
+
+func TestHandshakeResponse_Roundtrip(t *testing.T) {
+	// Write version=2 + nodeID="node-abc"
+	var buf bytes.Buffer
+	out := NewStreamOutput(&buf)
+
+	resp := &HandshakeResponse{
+		Version: 2,
+		NodeID:  "node-abc",
+	}
+	if err := resp.WriteTo(out); err != nil {
+		t.Fatalf("WriteTo failed: %v", err)
+	}
+
+	// Read back
+	in := NewStreamInput(&buf)
+	gotResp, err := ReadHandshakeResponse(in)
+	if err != nil {
+		t.Fatalf("ReadHandshakeResponse failed: %v", err)
+	}
+
+	// Verify both fields
+	if gotResp.Version != 2 {
+		t.Errorf("expected version 2, got %d", gotResp.Version)
+	}
+	if gotResp.NodeID != "node-abc" {
+		t.Errorf("expected nodeID 'node-abc', got '%s'", gotResp.NodeID)
+	}
+}
+
+func TestNegotiateVersion(t *testing.T) {
+	tests := []struct {
+		local    int32
+		remote   int32
+		expected int32
+	}{
+		{1, 1, 1},
+		{2, 1, 1},
+		{1, 3, 1},
+	}
+
+	for _, tt := range tests {
+		got := NegotiateVersion(tt.local, tt.remote)
+		if got != tt.expected {
+			t.Errorf("NegotiateVersion(%d, %d) = %d, want %d",
+				tt.local, tt.remote, got, tt.expected)
+		}
+	}
+}

--- a/server/transport/integration_test.go
+++ b/server/transport/integration_test.go
@@ -1,0 +1,202 @@
+package transport
+
+import (
+	"bytes"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestIntegration_IndexDocumentOverTransport(t *testing.T) {
+	// Start server TransportService
+	server, err := NewTransportService(TransportServiceConfig{
+		BindAddress: "127.0.0.1:0",
+		NodeName:    "server",
+		PoolConfigs: map[string]PoolConfig{
+			"generic": {Workers: 4, QueueSize: 100},
+			"index":   {Workers: 2, QueueSize: 50},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Stop()
+
+	// Register IndexDocument handler on server
+	RegisterTypedHandler(server, "indices:data/write/index", "index",
+		Reader[*IndexDocumentRequest](ReadIndexDocumentRequest),
+		func(req *IndexDocumentRequest, ch TransportChannel) error {
+			resp := &IndexDocumentResponse{
+				Index:       req.Index,
+				ID:          req.ID,
+				SeqNo:       1,
+				PrimaryTerm: 1,
+				Result:      "created",
+			}
+			return ch.SendResponse(resp)
+		},
+	)
+
+	// Start client TransportService
+	client, err := NewTransportService(TransportServiceConfig{
+		BindAddress: "127.0.0.1:0",
+		NodeName:    "client",
+		PoolConfigs: map[string]PoolConfig{
+			"generic": {Workers: 4, QueueSize: 100},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Stop()
+
+	// Connect client to server
+	serverNode := server.LocalNode()
+	if err := client.ConnectToNode(serverNode); err != nil {
+		t.Fatal(err)
+	}
+
+	// Send IndexDocument request
+	var mu sync.Mutex
+	var result *IndexDocumentResponse
+	done := make(chan struct{})
+
+	req := &IndexDocumentRequest{
+		Index:  "products",
+		ID:     "doc-1",
+		Source: json.RawMessage(`{"title":"widget"}`),
+	}
+
+	handler := TypedResponseHandler(
+		Reader[*IndexDocumentResponse](ReadIndexDocumentResponse),
+		"generic",
+		func(resp *IndexDocumentResponse) {
+			mu.Lock()
+			result = resp
+			mu.Unlock()
+			close(done)
+		},
+		func(err *RemoteTransportError) {
+			t.Errorf("unexpected error: %v", err)
+			close(done)
+		},
+	)
+
+	if err := client.SendRequest(serverNode, "indices:data/write/index", req,
+		TransportRequestOptions{ConnType: ConnTypeREG}, handler); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for response")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if result == nil {
+		t.Fatal("no response received")
+	}
+	if result.Index != "products" {
+		t.Errorf("Index: got %q, want %q", result.Index, "products")
+	}
+	if result.ID != "doc-1" {
+		t.Errorf("ID: got %q, want %q", result.ID, "doc-1")
+	}
+	if result.Result != "created" {
+		t.Errorf("Result: got %q, want %q", result.Result, "created")
+	}
+}
+
+func TestIntegration_SearchOverTransport(t *testing.T) {
+	server, err := NewTransportService(TransportServiceConfig{
+		BindAddress: "127.0.0.1:0",
+		NodeName:    "server",
+		PoolConfigs: map[string]PoolConfig{
+			"generic": {Workers: 4, QueueSize: 100},
+			"search":  {Workers: 2, QueueSize: 50},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Stop()
+
+	RegisterTypedHandler(server, "indices:data/read/search", "search",
+		Reader[*SearchRequestMsg](ReadSearchRequestMsg),
+		func(req *SearchRequestMsg, ch TransportChannel) error {
+			resp := &SearchResponseMsg{
+				Took:          5,
+				TotalHits:     1,
+				TotalRelation: "eq",
+				MaxScore:      1.0,
+				Hits: []SearchHitMsg{
+					{Index: req.Index, ID: "1", Score: 1.0, Source: json.RawMessage(`{"title":"result"}`)},
+				},
+			}
+			return ch.SendResponse(resp)
+		},
+	)
+
+	client, err := NewTransportService(TransportServiceConfig{
+		BindAddress: "127.0.0.1:0",
+		NodeName:    "client",
+		PoolConfigs: map[string]PoolConfig{
+			"generic": {Workers: 4, QueueSize: 100},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Stop()
+
+	serverNode := server.LocalNode()
+	if err := client.ConnectToNode(serverNode); err != nil {
+		t.Fatal(err)
+	}
+
+	var result *SearchResponseMsg
+	done := make(chan struct{})
+
+	req := &SearchRequestMsg{
+		Index:     "products",
+		QueryJSON: map[string]any{"match_all": map[string]any{}},
+		Size:      10,
+	}
+
+	handler := TypedResponseHandler(
+		Reader[*SearchResponseMsg](ReadSearchResponseMsg),
+		"generic",
+		func(resp *SearchResponseMsg) {
+			result = resp
+			close(done)
+		},
+		nil,
+	)
+
+	if err := client.SendRequest(serverNode, "indices:data/read/search", req,
+		TransportRequestOptions{ConnType: ConnTypeREG}, handler); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for response")
+	}
+
+	if result == nil {
+		t.Fatal("no response received")
+	}
+	if result.TotalHits != 1 {
+		t.Errorf("TotalHits: got %d, want 1", result.TotalHits)
+	}
+	if len(result.Hits) != 1 || result.Hits[0].ID != "1" {
+		t.Errorf("Hits: got %+v", result.Hits)
+	}
+	if !bytes.Equal(result.Hits[0].Source, json.RawMessage(`{"title":"result"}`)) {
+		t.Errorf("Source: got %q", result.Hits[0].Source)
+	}
+}

--- a/server/transport/integration_test.go
+++ b/server/transport/integration_test.go
@@ -13,9 +13,9 @@ func TestIntegration_IndexDocumentOverTransport(t *testing.T) {
 	server, err := NewTransportService(TransportServiceConfig{
 		BindAddress: "127.0.0.1:0",
 		NodeName:    "server",
-		PoolConfigs: map[string]PoolConfig{
-			"generic": {Workers: 4, QueueSize: 100},
-			"index":   {Workers: 2, QueueSize: 50},
+		PoolConfigs: map[PoolName]PoolConfig{
+			PoolGeneric: {Workers: 4, QueueSize: 100},
+			PoolIndex:   {Workers: 2, QueueSize: 50},
 		},
 	})
 	if err != nil {
@@ -24,7 +24,7 @@ func TestIntegration_IndexDocumentOverTransport(t *testing.T) {
 	defer server.Stop()
 
 	// Register IndexDocument handler on server
-	RegisterTypedHandler(server, "indices:data/write/index", "index",
+	registerHandler(server.requestHandlers, "indices:data/write/index", PoolIndex,
 		Reader[*IndexDocumentRequest](ReadIndexDocumentRequest),
 		func(req *IndexDocumentRequest, ch TransportChannel) error {
 			resp := &IndexDocumentResponse{
@@ -42,8 +42,8 @@ func TestIntegration_IndexDocumentOverTransport(t *testing.T) {
 	client, err := NewTransportService(TransportServiceConfig{
 		BindAddress: "127.0.0.1:0",
 		NodeName:    "client",
-		PoolConfigs: map[string]PoolConfig{
-			"generic": {Workers: 4, QueueSize: 100},
+		PoolConfigs: map[PoolName]PoolConfig{
+			PoolGeneric: {Workers: 4, QueueSize: 100},
 		},
 	})
 	if err != nil {
@@ -70,7 +70,7 @@ func TestIntegration_IndexDocumentOverTransport(t *testing.T) {
 
 	handler := TypedResponseHandler(
 		Reader[*IndexDocumentResponse](ReadIndexDocumentResponse),
-		"generic",
+		PoolGeneric,
 		func(resp *IndexDocumentResponse) {
 			mu.Lock()
 			result = resp
@@ -114,9 +114,9 @@ func TestIntegration_SearchOverTransport(t *testing.T) {
 	server, err := NewTransportService(TransportServiceConfig{
 		BindAddress: "127.0.0.1:0",
 		NodeName:    "server",
-		PoolConfigs: map[string]PoolConfig{
-			"generic": {Workers: 4, QueueSize: 100},
-			"search":  {Workers: 2, QueueSize: 50},
+		PoolConfigs: map[PoolName]PoolConfig{
+			PoolGeneric: {Workers: 4, QueueSize: 100},
+			PoolSearch:  {Workers: 2, QueueSize: 50},
 		},
 	})
 	if err != nil {
@@ -124,7 +124,7 @@ func TestIntegration_SearchOverTransport(t *testing.T) {
 	}
 	defer server.Stop()
 
-	RegisterTypedHandler(server, "indices:data/read/search", "search",
+	registerHandler(server.requestHandlers, "indices:data/read/search", PoolSearch,
 		Reader[*SearchRequestMsg](ReadSearchRequestMsg),
 		func(req *SearchRequestMsg, ch TransportChannel) error {
 			resp := &SearchResponseMsg{
@@ -143,8 +143,8 @@ func TestIntegration_SearchOverTransport(t *testing.T) {
 	client, err := NewTransportService(TransportServiceConfig{
 		BindAddress: "127.0.0.1:0",
 		NodeName:    "client",
-		PoolConfigs: map[string]PoolConfig{
-			"generic": {Workers: 4, QueueSize: 100},
+		PoolConfigs: map[PoolName]PoolConfig{
+			PoolGeneric: {Workers: 4, QueueSize: 100},
 		},
 	})
 	if err != nil {
@@ -168,7 +168,7 @@ func TestIntegration_SearchOverTransport(t *testing.T) {
 
 	handler := TypedResponseHandler(
 		Reader[*SearchResponseMsg](ReadSearchResponseMsg),
-		"generic",
+		PoolGeneric,
 		func(resp *SearchResponseMsg) {
 			result = resp
 			close(done)

--- a/server/transport/protocol.go
+++ b/server/transport/protocol.go
@@ -87,7 +87,7 @@ type Header struct {
 //	Status (1 byte)
 //	VarHeaderLength (4 bytes, big-endian)
 //	Variable Header: Action (string, request only) + ParentTaskID (string)
-func (h *Header) WriteTo(w io.Writer) error {
+func (h *Header) Encode(w io.Writer) error {
 	// Write marker
 	marker := []byte{markerByte1, markerByte2}
 	if _, err := w.Write(marker); err != nil {

--- a/server/transport/protocol.go
+++ b/server/transport/protocol.go
@@ -1,0 +1,251 @@
+package transport
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+// StatusFlags is a single byte bitfield for transport message status.
+// Bit 0: isRequest (1 = request, 0 = response)
+// Bit 1: isError (response carries serialized error)
+// Bit 2: isHandshake (handshake message)
+type StatusFlags byte
+
+const (
+	flagRequest   StatusFlags = 1 << 0 // 0x01
+	flagError     StatusFlags = 1 << 1 // 0x02
+	flagHandshake StatusFlags = 1 << 2 // 0x04
+)
+
+// IsRequest returns true if this is a request message.
+func (f StatusFlags) IsRequest() bool {
+	return f&flagRequest != 0
+}
+
+// IsError returns true if this response carries a serialized error.
+func (f StatusFlags) IsError() bool {
+	return f&flagError != 0
+}
+
+// IsHandshake returns true if this is a handshake message.
+func (f StatusFlags) IsHandshake() bool {
+	return f&flagHandshake != 0
+}
+
+// WithRequest returns a new StatusFlags with the isRequest bit set or cleared.
+func (f StatusFlags) WithRequest(v bool) StatusFlags {
+	if v {
+		return f | flagRequest
+	}
+	return f &^ flagRequest
+}
+
+// WithError returns a new StatusFlags with the isError bit set or cleared.
+func (f StatusFlags) WithError(v bool) StatusFlags {
+	if v {
+		return f | flagError
+	}
+	return f &^ flagError
+}
+
+// WithHandshake returns a new StatusFlags with the isHandshake bit set or cleared.
+func (f StatusFlags) WithHandshake(v bool) StatusFlags {
+	if v {
+		return f | flagHandshake
+	}
+	return f &^ flagHandshake
+}
+
+// Wire format constants.
+const (
+	// FixedHeaderSize is the size of the fixed portion of the header:
+	// marker(2) + messageLength(4) + requestID(8) + status(1) + varHeaderLen(4) = 19 bytes
+	FixedHeaderSize = 19
+
+	// Marker bytes that start every message.
+	markerByte1 = 'E'
+	markerByte2 = 'S'
+)
+
+// Header represents a transport protocol message header.
+type Header struct {
+	MessageLength   int32 // total message length after marker+length fields
+	RequestID       int64
+	Status          StatusFlags
+	Action          string // only for requests
+	ParentTaskID    string
+	varHeaderLength int32 // stored for payload size calculation
+}
+
+// WriteTo serializes the complete header to the given writer.
+// Wire format:
+//
+//	Marker: "ES" (2 bytes)
+//	MessageLength (4 bytes, big-endian)
+//	RequestID (8 bytes, big-endian)
+//	Status (1 byte)
+//	VarHeaderLength (4 bytes, big-endian)
+//	Variable Header: Action (string, request only) + ParentTaskID (string)
+func (h *Header) WriteTo(w io.Writer) error {
+	// Write marker
+	marker := []byte{markerByte1, markerByte2}
+	if _, err := w.Write(marker); err != nil {
+		return fmt.Errorf("writing marker: %w", err)
+	}
+
+	// Write MessageLength
+	var buf [4]byte
+	binary.BigEndian.PutUint32(buf[:], uint32(h.MessageLength))
+	if _, err := w.Write(buf[:]); err != nil {
+		return fmt.Errorf("writing message length: %w", err)
+	}
+
+	// Write RequestID
+	var buf8 [8]byte
+	binary.BigEndian.PutUint64(buf8[:], uint64(h.RequestID))
+	if _, err := w.Write(buf8[:]); err != nil {
+		return fmt.Errorf("writing request ID: %w", err)
+	}
+
+	// Write Status
+	if _, err := w.Write([]byte{byte(h.Status)}); err != nil {
+		return fmt.Errorf("writing status: %w", err)
+	}
+
+	// Build variable header in memory to compute its length
+	var varHeaderBuf []byte
+	stream := NewStreamOutput(&bufferWriter{buf: &varHeaderBuf})
+
+	// Action is only written for requests
+	if h.Status.IsRequest() {
+		if err := stream.WriteString(h.Action); err != nil {
+			return fmt.Errorf("writing action: %w", err)
+		}
+	}
+
+	// ParentTaskID always written
+	if err := stream.WriteString(h.ParentTaskID); err != nil {
+		return fmt.Errorf("writing parent task ID: %w", err)
+	}
+
+	// Write VarHeaderLength
+	binary.BigEndian.PutUint32(buf[:], uint32(len(varHeaderBuf)))
+	if _, err := w.Write(buf[:]); err != nil {
+		return fmt.Errorf("writing var header length: %w", err)
+	}
+
+	// Write variable header
+	if _, err := w.Write(varHeaderBuf); err != nil {
+		return fmt.Errorf("writing variable header: %w", err)
+	}
+
+	return nil
+}
+
+// ReadHeader reads and parses a header from the given reader.
+func ReadHeader(r io.Reader) (*Header, error) {
+	// Read and verify marker
+	marker := make([]byte, 2)
+	if _, err := io.ReadFull(r, marker); err != nil {
+		return nil, fmt.Errorf("reading marker: %w", err)
+	}
+	if marker[0] != markerByte1 || marker[1] != markerByte2 {
+		return nil, fmt.Errorf("invalid marker: expected [%c%c], got [%c%c]",
+			markerByte1, markerByte2, marker[0], marker[1])
+	}
+
+	// Read MessageLength
+	var buf [4]byte
+	if _, err := io.ReadFull(r, buf[:]); err != nil {
+		return nil, fmt.Errorf("reading message length: %w", err)
+	}
+	messageLength := int32(binary.BigEndian.Uint32(buf[:]))
+
+	// Read RequestID
+	var buf8 [8]byte
+	if _, err := io.ReadFull(r, buf8[:]); err != nil {
+		return nil, fmt.Errorf("reading request ID: %w", err)
+	}
+	requestID := int64(binary.BigEndian.Uint64(buf8[:]))
+
+	// Read Status
+	var statusBuf [1]byte
+	if _, err := io.ReadFull(r, statusBuf[:]); err != nil {
+		return nil, fmt.Errorf("reading status: %w", err)
+	}
+	status := StatusFlags(statusBuf[0])
+
+	// Read VarHeaderLength
+	if _, err := io.ReadFull(r, buf[:]); err != nil {
+		return nil, fmt.Errorf("reading var header length: %w", err)
+	}
+	varHeaderLength := int32(binary.BigEndian.Uint32(buf[:]))
+
+	// Read variable header
+	varHeaderData := make([]byte, varHeaderLength)
+	if _, err := io.ReadFull(r, varHeaderData); err != nil {
+		return nil, fmt.Errorf("reading variable header: %w", err)
+	}
+
+	// Parse variable header
+	stream := NewStreamInput(&bufferReader{buf: varHeaderData})
+	var action string
+	var parentTaskID string
+
+	// Action is only present for requests
+	if status.IsRequest() {
+		var err error
+		action, err = stream.ReadString()
+		if err != nil {
+			return nil, fmt.Errorf("reading action: %w", err)
+		}
+	}
+
+	// ParentTaskID always present
+	var err error
+	parentTaskID, err = stream.ReadString()
+	if err != nil {
+		return nil, fmt.Errorf("reading parent task ID: %w", err)
+	}
+
+	return &Header{
+		MessageLength:   messageLength,
+		RequestID:       requestID,
+		Status:          status,
+		Action:          action,
+		ParentTaskID:    parentTaskID,
+		varHeaderLength: varHeaderLength,
+	}, nil
+}
+
+// PayloadSize returns the size of the payload following this header.
+// PayloadSize = MessageLength - requestID(8) - status(1) - varHeaderLen(4) - varHeaderLength
+func (h *Header) PayloadSize() int {
+	return int(h.MessageLength) - 8 - 1 - 4 - int(h.varHeaderLength)
+}
+
+// bufferWriter is a simple writer that appends to a byte slice.
+type bufferWriter struct {
+	buf *[]byte
+}
+
+func (w *bufferWriter) Write(p []byte) (n int, err error) {
+	*w.buf = append(*w.buf, p...)
+	return len(p), nil
+}
+
+// bufferReader is a simple reader that reads from a byte slice.
+type bufferReader struct {
+	buf []byte
+	pos int
+}
+
+func (r *bufferReader) Read(p []byte) (n int, err error) {
+	if r.pos >= len(r.buf) {
+		return 0, io.EOF
+	}
+	n = copy(p, r.buf[r.pos:])
+	r.pos += n
+	return n, nil
+}

--- a/server/transport/protocol.go
+++ b/server/transport/protocol.go
@@ -1,6 +1,7 @@
 package transport
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -189,7 +190,7 @@ func ReadHeader(r io.Reader) (*Header, error) {
 	}
 
 	// Parse variable header
-	stream := NewStreamInput(&bufferReader{buf: varHeaderData})
+	stream := NewStreamInput(bytes.NewReader(varHeaderData))
 	var action string
 	var parentTaskID string
 
@@ -235,17 +236,3 @@ func (w *bufferWriter) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-// bufferReader is a simple reader that reads from a byte slice.
-type bufferReader struct {
-	buf []byte
-	pos int
-}
-
-func (r *bufferReader) Read(p []byte) (n int, err error) {
-	if r.pos >= len(r.buf) {
-		return 0, io.EOF
-	}
-	n = copy(p, r.buf[r.pos:])
-	r.pos += n
-	return n, nil
-}

--- a/server/transport/protocol_test.go
+++ b/server/transport/protocol_test.go
@@ -1,0 +1,262 @@
+package transport
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestStatusFlags tests setting and getting each flag.
+func TestStatusFlags(t *testing.T) {
+	var flags StatusFlags
+
+	// Test IsRequest
+	if flags.IsRequest() {
+		t.Error("expected IsRequest to be false initially")
+	}
+	flags = flags.WithRequest(true)
+	if !flags.IsRequest() {
+		t.Error("expected IsRequest to be true after WithRequest(true)")
+	}
+	flags = flags.WithRequest(false)
+	if flags.IsRequest() {
+		t.Error("expected IsRequest to be false after WithRequest(false)")
+	}
+
+	// Test IsError
+	if flags.IsError() {
+		t.Error("expected IsError to be false initially")
+	}
+	flags = flags.WithError(true)
+	if !flags.IsError() {
+		t.Error("expected IsError to be true after WithError(true)")
+	}
+	flags = flags.WithError(false)
+	if flags.IsError() {
+		t.Error("expected IsError to be false after WithError(false)")
+	}
+
+	// Test IsHandshake
+	if flags.IsHandshake() {
+		t.Error("expected IsHandshake to be false initially")
+	}
+	flags = flags.WithHandshake(true)
+	if !flags.IsHandshake() {
+		t.Error("expected IsHandshake to be true after WithHandshake(true)")
+	}
+	flags = flags.WithHandshake(false)
+	if flags.IsHandshake() {
+		t.Error("expected IsHandshake to be false after WithHandshake(false)")
+	}
+
+	// Test multiple flags at once
+	flags = StatusFlags(0).WithRequest(true).WithError(true)
+	if !flags.IsRequest() {
+		t.Error("expected IsRequest to be true")
+	}
+	if !flags.IsError() {
+		t.Error("expected IsError to be true")
+	}
+	if flags.IsHandshake() {
+		t.Error("expected IsHandshake to be false")
+	}
+}
+
+// TestHeaderRequestRoundtrip tests roundtrip serialization of a request header.
+func TestHeaderRequestRoundtrip(t *testing.T) {
+	// Create a request header
+	original := &Header{
+		RequestID:    42,
+		Status:       StatusFlags(0).WithRequest(true),
+		Action:       "indices:data/write/index",
+		ParentTaskID: "node1:5",
+	}
+
+	// Calculate variable header length for MessageLength
+	var varBuf []byte
+	varStream := NewStreamOutput(&bufferWriter{buf: &varBuf})
+	if err := varStream.WriteString(original.Action); err != nil {
+		t.Fatalf("failed to write action: %v", err)
+	}
+	if err := varStream.WriteString(original.ParentTaskID); err != nil {
+		t.Fatalf("failed to write parent task ID: %v", err)
+	}
+	varHeaderLen := int32(len(varBuf))
+	original.varHeaderLength = varHeaderLen
+	original.MessageLength = 8 + 1 + 4 + varHeaderLen // requestID + status + varHeaderLen field + varHeader
+
+	// Write to buffer
+	var buf bytes.Buffer
+	if err := original.WriteTo(&buf); err != nil {
+		t.Fatalf("failed to write header: %v", err)
+	}
+
+	// Read back
+	parsed, err := ReadHeader(&buf)
+	if err != nil {
+		t.Fatalf("failed to read header: %v", err)
+	}
+
+	// Verify fields
+	if parsed.MessageLength != original.MessageLength {
+		t.Errorf("MessageLength mismatch: got %d, want %d", parsed.MessageLength, original.MessageLength)
+	}
+	if parsed.RequestID != original.RequestID {
+		t.Errorf("RequestID mismatch: got %d, want %d", parsed.RequestID, original.RequestID)
+	}
+	if parsed.Status != original.Status {
+		t.Errorf("Status mismatch: got %d, want %d", parsed.Status, original.Status)
+	}
+	if !parsed.Status.IsRequest() {
+		t.Error("expected Status.IsRequest() to be true")
+	}
+	if parsed.Action != original.Action {
+		t.Errorf("Action mismatch: got %q, want %q", parsed.Action, original.Action)
+	}
+	if parsed.ParentTaskID != original.ParentTaskID {
+		t.Errorf("ParentTaskID mismatch: got %q, want %q", parsed.ParentTaskID, original.ParentTaskID)
+	}
+	if parsed.varHeaderLength != original.varHeaderLength {
+		t.Errorf("varHeaderLength mismatch: got %d, want %d", parsed.varHeaderLength, original.varHeaderLength)
+	}
+}
+
+// TestHeaderResponseRoundtrip tests roundtrip serialization of a response header.
+func TestHeaderResponseRoundtrip(t *testing.T) {
+	// Create a response header (no action)
+	original := &Header{
+		RequestID:    99,
+		Status:       StatusFlags(0), // isRequest=false
+		ParentTaskID: "",
+	}
+
+	// Calculate variable header length for MessageLength
+	var varBuf []byte
+	varStream := NewStreamOutput(&bufferWriter{buf: &varBuf})
+	if err := varStream.WriteString(original.ParentTaskID); err != nil {
+		t.Fatalf("failed to write parent task ID: %v", err)
+	}
+	varHeaderLen := int32(len(varBuf))
+	original.varHeaderLength = varHeaderLen
+	original.MessageLength = 8 + 1 + 4 + varHeaderLen // requestID + status + varHeaderLen field + varHeader
+
+	// Write to buffer
+	var buf bytes.Buffer
+	if err := original.WriteTo(&buf); err != nil {
+		t.Fatalf("failed to write header: %v", err)
+	}
+
+	// Read back
+	parsed, err := ReadHeader(&buf)
+	if err != nil {
+		t.Fatalf("failed to read header: %v", err)
+	}
+
+	// Verify fields
+	if parsed.MessageLength != original.MessageLength {
+		t.Errorf("MessageLength mismatch: got %d, want %d", parsed.MessageLength, original.MessageLength)
+	}
+	if parsed.RequestID != original.RequestID {
+		t.Errorf("RequestID mismatch: got %d, want %d", parsed.RequestID, original.RequestID)
+	}
+	if parsed.Status != original.Status {
+		t.Errorf("Status mismatch: got %d, want %d", parsed.Status, original.Status)
+	}
+	if parsed.Status.IsRequest() {
+		t.Error("expected Status.IsRequest() to be false for response")
+	}
+	if parsed.Action != "" {
+		t.Errorf("Action should be empty for response, got %q", parsed.Action)
+	}
+	if parsed.ParentTaskID != original.ParentTaskID {
+		t.Errorf("ParentTaskID mismatch: got %q, want %q", parsed.ParentTaskID, original.ParentTaskID)
+	}
+	if parsed.varHeaderLength != original.varHeaderLength {
+		t.Errorf("varHeaderLength mismatch: got %d, want %d", parsed.varHeaderLength, original.varHeaderLength)
+	}
+}
+
+// TestHeaderMarkerVerification tests that the marker bytes are 'E', 'S'.
+func TestHeaderMarkerVerification(t *testing.T) {
+	// Create a simple header
+	header := &Header{
+		RequestID:    1,
+		Status:       StatusFlags(0),
+		ParentTaskID: "",
+	}
+
+	// Calculate MessageLength
+	var varBuf []byte
+	varStream := NewStreamOutput(&bufferWriter{buf: &varBuf})
+	if err := varStream.WriteString(header.ParentTaskID); err != nil {
+		t.Fatalf("failed to write parent task ID: %v", err)
+	}
+	varHeaderLen := int32(len(varBuf))
+	header.varHeaderLength = varHeaderLen
+	header.MessageLength = 8 + 1 + 4 + varHeaderLen
+
+	// Write to buffer
+	var buf bytes.Buffer
+	if err := header.WriteTo(&buf); err != nil {
+		t.Fatalf("failed to write header: %v", err)
+	}
+
+	// Verify first two bytes are 'E', 'S'
+	data := buf.Bytes()
+	if len(data) < 2 {
+		t.Fatal("buffer too short")
+	}
+	if data[0] != 'E' {
+		t.Errorf("first marker byte: got %c, want E", data[0])
+	}
+	if data[1] != 'S' {
+		t.Errorf("second marker byte: got %c, want S", data[1])
+	}
+
+	// Test invalid marker
+	invalidBuf := bytes.NewBuffer([]byte("XX"))
+	invalidBuf.Write(data[2:]) // rest of the header
+	_, err := ReadHeader(invalidBuf)
+	if err == nil {
+		t.Error("expected error for invalid marker, got nil")
+	}
+}
+
+// TestHeaderPayloadSize tests that PayloadSize is calculated correctly.
+func TestHeaderPayloadSize(t *testing.T) {
+	// Create a header with known sizes
+	header := &Header{
+		RequestID:    42,
+		Status:       StatusFlags(0).WithRequest(true),
+		Action:       "test:action",
+		ParentTaskID: "task1",
+	}
+
+	// Calculate variable header length
+	var varBuf []byte
+	varStream := NewStreamOutput(&bufferWriter{buf: &varBuf})
+	if err := varStream.WriteString(header.Action); err != nil {
+		t.Fatalf("failed to write action: %v", err)
+	}
+	if err := varStream.WriteString(header.ParentTaskID); err != nil {
+		t.Fatalf("failed to write parent task ID: %v", err)
+	}
+	varHeaderLen := int32(len(varBuf))
+	header.varHeaderLength = varHeaderLen
+
+	// Set MessageLength to include some payload
+	payloadSize := 100
+	header.MessageLength = 8 + 1 + 4 + varHeaderLen + int32(payloadSize)
+
+	// Verify PayloadSize calculation
+	calculatedPayloadSize := header.PayloadSize()
+	if calculatedPayloadSize != payloadSize {
+		t.Errorf("PayloadSize mismatch: got %d, want %d", calculatedPayloadSize, payloadSize)
+	}
+
+	// Test with zero payload
+	header.MessageLength = 8 + 1 + 4 + varHeaderLen
+	calculatedPayloadSize = header.PayloadSize()
+	if calculatedPayloadSize != 0 {
+		t.Errorf("PayloadSize for zero payload: got %d, want 0", calculatedPayloadSize)
+	}
+}

--- a/server/transport/protocol_test.go
+++ b/server/transport/protocol_test.go
@@ -86,7 +86,7 @@ func TestHeaderRequestRoundtrip(t *testing.T) {
 
 	// Write to buffer
 	var buf bytes.Buffer
-	if err := original.WriteTo(&buf); err != nil {
+	if err := original.Encode(&buf); err != nil {
 		t.Fatalf("failed to write header: %v", err)
 	}
 
@@ -141,7 +141,7 @@ func TestHeaderResponseRoundtrip(t *testing.T) {
 
 	// Write to buffer
 	var buf bytes.Buffer
-	if err := original.WriteTo(&buf); err != nil {
+	if err := original.Encode(&buf); err != nil {
 		t.Fatalf("failed to write header: %v", err)
 	}
 
@@ -196,7 +196,7 @@ func TestHeaderMarkerVerification(t *testing.T) {
 
 	// Write to buffer
 	var buf bytes.Buffer
-	if err := header.WriteTo(&buf); err != nil {
+	if err := header.Encode(&buf); err != nil {
 		t.Fatalf("failed to write header: %v", err)
 	}
 

--- a/server/transport/registry.go
+++ b/server/transport/registry.go
@@ -1,0 +1,103 @@
+package transport
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// ResponseContext holds the state for an in-flight outbound request.
+type ResponseContext struct {
+	Handler   any
+	Action    string
+	NodeID    string
+	Timeout   time.Duration
+	CreatedAt time.Time
+}
+
+// ResponseHandlers tracks in-flight requests by requestID.
+type ResponseHandlers struct {
+	nextID   atomic.Int64
+	handlers sync.Map // int64 → *ResponseContext
+}
+
+func NewResponseHandlers() *ResponseHandlers {
+	return &ResponseHandlers{}
+}
+
+func (rh *ResponseHandlers) Add(ctx *ResponseContext) int64 {
+	id := rh.nextID.Add(1)
+	rh.handlers.Store(id, ctx)
+	return id
+}
+
+func (rh *ResponseHandlers) Remove(id int64) *ResponseContext {
+	v, ok := rh.handlers.LoadAndDelete(id)
+	if !ok {
+		return nil
+	}
+	return v.(*ResponseContext)
+}
+
+// Range iterates over all in-flight handlers. Used by timeout reaper.
+func (rh *ResponseHandlers) Range(fn func(id int64, ctx *ResponseContext) bool) {
+	rh.handlers.Range(func(key, value any) bool {
+		return fn(key.(int64), value.(*ResponseContext))
+	})
+}
+
+// requestHandlerEntry stores a registered request handler with a type-erased dispatch closure.
+type requestHandlerEntry struct {
+	action   string
+	executor string
+	dispatch func(payload *StreamInput, channel TransportChannel)
+}
+
+// RequestHandlerMap maps action names to handlers.
+type RequestHandlerMap struct {
+	mu       sync.RWMutex
+	handlers map[string]*requestHandlerEntry
+}
+
+func NewRequestHandlerMap() *RequestHandlerMap {
+	return &RequestHandlerMap{
+		handlers: make(map[string]*requestHandlerEntry),
+	}
+}
+
+func (m *RequestHandlerMap) Register(entry *requestHandlerEntry) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.handlers[entry.action] = entry
+}
+
+func (m *RequestHandlerMap) Get(action string) *requestHandlerEntry {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.handlers[action]
+}
+
+// RegisterHandler is a typed helper that creates a dispatch closure capturing concrete types.
+func RegisterHandler[T any](
+	m *RequestHandlerMap,
+	action string,
+	executor string,
+	reader Reader[T],
+	handler func(request T, channel TransportChannel) error,
+) {
+	m.Register(&requestHandlerEntry{
+		action:   action,
+		executor: executor,
+		dispatch: func(payload *StreamInput, channel TransportChannel) {
+			req, err := reader(payload)
+			if err != nil {
+				channel.SendError(fmt.Errorf("deserialize request: %w", err))
+				return
+			}
+			if err := handler(req, channel); err != nil {
+				channel.SendError(err)
+			}
+		},
+	})
+}

--- a/server/transport/registry.go
+++ b/server/transport/registry.go
@@ -1,19 +1,24 @@
 package transport
 
 import (
-	"fmt"
+	"context"
 	"sync"
 	"sync/atomic"
-	"time"
 )
+
+// ResponseHandler handles the result of an outbound request.
+type ResponseHandler interface {
+	ReadAndHandle(*StreamInput) error
+	HandleError(*RemoteTransportError)
+}
 
 // ResponseContext holds the state for an in-flight outbound request.
 type ResponseContext struct {
-	Handler   any
-	Action    string
-	NodeID    string
-	Timeout   time.Duration
-	CreatedAt time.Time
+	Handler ResponseHandler
+	Action  string
+	NodeID  string
+	Ctx     context.Context
+	Cancel  context.CancelFunc
 }
 
 // ResponseHandlers tracks in-flight requests by requestID.
@@ -40,17 +45,10 @@ func (rh *ResponseHandlers) Remove(id int64) *ResponseContext {
 	return v.(*ResponseContext)
 }
 
-// Range iterates over all in-flight handlers. Used by timeout reaper.
-func (rh *ResponseHandlers) Range(fn func(id int64, ctx *ResponseContext) bool) {
-	rh.handlers.Range(func(key, value any) bool {
-		return fn(key.(int64), value.(*ResponseContext))
-	})
-}
-
 // requestHandlerEntry stores a registered request handler with a type-erased dispatch closure.
 type requestHandlerEntry struct {
 	action   string
-	executor string
+	executor PoolName
 	dispatch func(payload *StreamInput, channel TransportChannel)
 }
 
@@ -76,28 +74,4 @@ func (m *RequestHandlerMap) Get(action string) *requestHandlerEntry {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.handlers[action]
-}
-
-// RegisterHandler is a typed helper that creates a dispatch closure capturing concrete types.
-func RegisterHandler[T any](
-	m *RequestHandlerMap,
-	action string,
-	executor string,
-	reader Reader[T],
-	handler func(request T, channel TransportChannel) error,
-) {
-	m.Register(&requestHandlerEntry{
-		action:   action,
-		executor: executor,
-		dispatch: func(payload *StreamInput, channel TransportChannel) {
-			req, err := reader(payload)
-			if err != nil {
-				channel.SendError(fmt.Errorf("deserialize request: %w", err))
-				return
-			}
-			if err := handler(req, channel); err != nil {
-				channel.SendError(err)
-			}
-		},
-	})
 }

--- a/server/transport/registry_test.go
+++ b/server/transport/registry_test.go
@@ -2,11 +2,18 @@ package transport
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"sync"
 	"testing"
 	"time"
 )
+
+// noopResponseHandler is a stub ResponseHandler for registry tests.
+type noopResponseHandler struct{}
+
+func (noopResponseHandler) ReadAndHandle(*StreamInput) error  { return nil }
+func (noopResponseHandler) HandleError(*RemoteTransportError) {}
 
 // Test types for typed dispatch test
 type testMsg struct{ Value string }
@@ -21,12 +28,14 @@ func readTestMsg(in *StreamInput) (*testMsg, error) {
 func TestResponseHandlers_AddAndRemove(t *testing.T) {
 	rh := NewResponseHandlers()
 
+	reqCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	ctx := &ResponseContext{
-		Handler:   "test-handler",
-		Action:    "test-action",
-		NodeID:    "node-1",
-		Timeout:   5 * time.Second,
-		CreatedAt: time.Now(),
+		Handler: noopResponseHandler{},
+		Action:  "test-action",
+		NodeID:  "node-1",
+		Ctx:     reqCtx,
+		Cancel:  cancel,
 	}
 
 	id := rh.Add(ctx)
@@ -96,7 +105,7 @@ func TestRequestHandlerMap_RegisterAndGet(t *testing.T) {
 
 	entry := &requestHandlerEntry{
 		action:   "test-action",
-		executor: "test-executor",
+		executor: PoolGeneric,
 		dispatch: func(payload *StreamInput, channel TransportChannel) {},
 	}
 
@@ -109,8 +118,8 @@ func TestRequestHandlerMap_RegisterAndGet(t *testing.T) {
 	if retrieved.action != "test-action" {
 		t.Errorf("expected action test-action, got %s", retrieved.action)
 	}
-	if retrieved.executor != "test-executor" {
-		t.Errorf("expected executor test-executor, got %s", retrieved.executor)
+	if retrieved.executor != PoolGeneric {
+		t.Errorf("expected executor %s, got %s", PoolGeneric, retrieved.executor)
 	}
 
 	// Get unknown action
@@ -129,7 +138,7 @@ func TestRegisterHandler_TypedDispatch(t *testing.T) {
 		return channel.SendResponse(&testMsg{Value: "response:" + request.Value})
 	}
 
-	RegisterHandler(m, "test-action", "test-executor", readTestMsg, handler)
+	registerHandler(m, "test-action", PoolGeneric, readTestMsg, handler)
 
 	entry := m.Get("test-action")
 	if entry == nil {

--- a/server/transport/registry_test.go
+++ b/server/transport/registry_test.go
@@ -1,0 +1,184 @@
+package transport
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Test types for typed dispatch test
+type testMsg struct{ Value string }
+
+func (m *testMsg) WriteTo(out *StreamOutput) error { return out.WriteString(m.Value) }
+
+func readTestMsg(in *StreamInput) (*testMsg, error) {
+	v, err := in.ReadString()
+	return &testMsg{Value: v}, err
+}
+
+func TestResponseHandlers_AddAndRemove(t *testing.T) {
+	rh := NewResponseHandlers()
+
+	ctx := &ResponseContext{
+		Handler:   "test-handler",
+		Action:    "test-action",
+		NodeID:    "node-1",
+		Timeout:   5 * time.Second,
+		CreatedAt: time.Now(),
+	}
+
+	id := rh.Add(ctx)
+	if id <= 0 {
+		t.Fatalf("expected positive ID, got %d", id)
+	}
+
+	retrieved := rh.Remove(id)
+	if retrieved == nil {
+		t.Fatal("expected to retrieve context, got nil")
+	}
+	if retrieved.Action != "test-action" {
+		t.Errorf("expected action test-action, got %s", retrieved.Action)
+	}
+	if retrieved.NodeID != "node-1" {
+		t.Errorf("expected nodeID node-1, got %s", retrieved.NodeID)
+	}
+
+	// Second remove should return nil
+	second := rh.Remove(id)
+	if second != nil {
+		t.Errorf("expected nil on second remove, got %v", second)
+	}
+}
+
+func TestResponseHandlers_IDsAreUnique(t *testing.T) {
+	rh := NewResponseHandlers()
+	seen := make(map[int64]bool)
+
+	for i := range 100 {
+		ctx := &ResponseContext{Action: fmt.Sprintf("action-%d", i)}
+		id := rh.Add(ctx)
+		if seen[id] {
+			t.Fatalf("duplicate ID detected: %d", id)
+		}
+		seen[id] = true
+	}
+
+	if len(seen) != 100 {
+		t.Fatalf("expected 100 unique IDs, got %d", len(seen))
+	}
+}
+
+func TestResponseHandlers_ConcurrentAddRemove(t *testing.T) {
+	rh := NewResponseHandlers()
+	var wg sync.WaitGroup
+
+	for i := range 100 {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			ctx := &ResponseContext{Action: fmt.Sprintf("action-%d", n)}
+			id := rh.Add(ctx)
+			time.Sleep(time.Millisecond)
+			retrieved := rh.Remove(id)
+			if retrieved == nil {
+				t.Errorf("goroutine %d: failed to retrieve context", n)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+func TestRequestHandlerMap_RegisterAndGet(t *testing.T) {
+	m := NewRequestHandlerMap()
+
+	entry := &requestHandlerEntry{
+		action:   "test-action",
+		executor: "test-executor",
+		dispatch: func(payload *StreamInput, channel TransportChannel) {},
+	}
+
+	m.Register(entry)
+
+	retrieved := m.Get("test-action")
+	if retrieved == nil {
+		t.Fatal("expected to retrieve entry, got nil")
+	}
+	if retrieved.action != "test-action" {
+		t.Errorf("expected action test-action, got %s", retrieved.action)
+	}
+	if retrieved.executor != "test-executor" {
+		t.Errorf("expected executor test-executor, got %s", retrieved.executor)
+	}
+
+	// Get unknown action
+	unknown := m.Get("unknown-action")
+	if unknown != nil {
+		t.Errorf("expected nil for unknown action, got %v", unknown)
+	}
+}
+
+func TestRegisterHandler_TypedDispatch(t *testing.T) {
+	m := NewRequestHandlerMap()
+
+	var receivedMsg *testMsg
+	handler := func(request *testMsg, channel TransportChannel) error {
+		receivedMsg = request
+		return channel.SendResponse(&testMsg{Value: "response:" + request.Value})
+	}
+
+	RegisterHandler(m, "test-action", "test-executor", readTestMsg, handler)
+
+	entry := m.Get("test-action")
+	if entry == nil {
+		t.Fatal("expected to retrieve registered handler")
+	}
+
+	// Create a test message
+	var inputBuf bytes.Buffer
+	out := NewStreamOutput(&inputBuf)
+	testInput := &testMsg{Value: "hello"}
+	if err := testInput.WriteTo(out); err != nil {
+		t.Fatalf("failed to serialize test input: %v", err)
+	}
+
+	// Create a mock channel
+	var responseBuf bytes.Buffer
+	channel := &mockTransportChannel{writer: &responseBuf}
+
+	// Dispatch the message
+	in := NewStreamInput(&inputBuf)
+	entry.dispatch(in, channel)
+
+	// Verify the handler was called
+	if receivedMsg == nil {
+		t.Fatal("handler was not called")
+	}
+	if receivedMsg.Value != "hello" {
+		t.Errorf("expected Value=hello, got %s", receivedMsg.Value)
+	}
+
+	// Verify response was sent
+	if !channel.responseSent {
+		t.Error("expected response to be sent")
+	}
+}
+
+// Mock channel for testing
+type mockTransportChannel struct {
+	writer       *bytes.Buffer
+	responseSent bool
+	errorSent    bool
+}
+
+func (m *mockTransportChannel) SendResponse(response Writeable) error {
+	m.responseSent = true
+	return response.WriteTo(NewStreamOutput(m.writer))
+}
+
+func (m *mockTransportChannel) SendError(err error) error {
+	m.errorSent = true
+	return nil
+}

--- a/server/transport/service.go
+++ b/server/transport/service.go
@@ -1,0 +1,246 @@
+package transport
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// TransportServiceConfig configures a TransportService.
+type TransportServiceConfig struct {
+	BindAddress string
+	NodeName    string
+	PoolConfigs map[string]PoolConfig
+	ConnProfile ConnectionProfile // optional, uses default if zero
+}
+
+// TransportService wraps connection management, handler registry, and dispatch.
+type TransportService struct {
+	localNode        DiscoveryNode
+	transport        *TcpTransport
+	connectionMgr    *ConnectionManager
+	requestHandlers  *RequestHandlerMap
+	responseHandlers *ResponseHandlers
+	threadPool       *ThreadPool
+	outbound         *OutboundHandler
+}
+
+// NewTransportService creates and starts a new TransportService.
+func NewTransportService(config TransportServiceConfig) (*TransportService, error) {
+	nodeID := uuid.New().String()
+	localNode := DiscoveryNode{ID: nodeID, Name: config.NodeName}
+
+	requestHandlers := NewRequestHandlerMap()
+	responseHandlers := NewResponseHandlers()
+	threadPool := NewThreadPool(config.PoolConfigs)
+
+	transport := NewTcpTransport(localNode, requestHandlers, responseHandlers, threadPool)
+
+	addr, err := transport.Start(config.BindAddress)
+	if err != nil {
+		threadPool.Shutdown()
+		return nil, err
+	}
+	localNode.Address = addr
+
+	profile := config.ConnProfile
+	if len(profile.ConnPerType) == 0 {
+		profile = ConnectionProfile{
+			ConnPerType:      map[ConnectionType]int{ConnTypeREG: 1},
+			ConnectTimeout:   5 * time.Second,
+			HandshakeTimeout: 5 * time.Second,
+		}
+	}
+	connectionMgr := NewConnectionManager(transport, profile)
+
+	return &TransportService{
+		localNode:        localNode,
+		transport:        transport,
+		connectionMgr:    connectionMgr,
+		requestHandlers:  requestHandlers,
+		responseHandlers: responseHandlers,
+		threadPool:       threadPool,
+		outbound:         NewOutboundHandler(),
+	}, nil
+}
+
+// LocalNode returns the local node info.
+func (ts *TransportService) LocalNode() DiscoveryNode {
+	return ts.localNode
+}
+
+// RegisterTypedHandler registers a typed request handler on the service.
+func RegisterTypedHandler[T any](ts *TransportService, action, executor string, reader Reader[T], handler func(T, TransportChannel) error) {
+	RegisterHandler(ts.requestHandlers, action, executor, reader, handler)
+}
+
+// SendRequest sends a request to the given node. If the node is the local node,
+// the request is dispatched locally. Otherwise it is sent over the network.
+func (ts *TransportService) SendRequest(node DiscoveryNode, action string, request Writeable, options TransportRequestOptions, handler *responseHandlerWrapper) error {
+	if node.ID == ts.localNode.ID {
+		return ts.sendLocalRequest(action, request, handler)
+	}
+	return ts.sendRemoteRequest(node, action, request, options, handler)
+}
+
+func (ts *TransportService) sendLocalRequest(action string, request Writeable, handler *responseHandlerWrapper) error {
+	entry := ts.requestHandlers.Get(action)
+	if entry == nil {
+		return fmt.Errorf("no handler registered for action %q", action)
+	}
+
+	// Serialize request to bytes
+	var buf bytes.Buffer
+	out := NewStreamOutput(&buf)
+	if err := request.WriteTo(out); err != nil {
+		return fmt.Errorf("serialize local request: %w", err)
+	}
+
+	in := NewStreamInput(bytes.NewReader(buf.Bytes()))
+	channel := &localTransportChannel{
+		handler:    handler,
+		threadPool: ts.threadPool,
+	}
+
+	executor := ts.threadPool.Get(entry.executor)
+	return executor.Execute(func() {
+		entry.dispatch(in, channel)
+	})
+}
+
+func (ts *TransportService) sendRemoteRequest(node DiscoveryNode, action string, request Writeable, options TransportRequestOptions, handler *responseHandlerWrapper) error {
+	conn, err := ts.connectionMgr.GetConnection(node.ID)
+	if err != nil {
+		return err
+	}
+
+	ctx := &ResponseContext{
+		Handler:   handler,
+		Action:    action,
+		NodeID:    node.ID,
+		Timeout:   options.Timeout,
+		CreatedAt: time.Now(),
+	}
+	requestID := ts.responseHandlers.Add(ctx)
+
+	tcpConn, err := conn.Conn(options.ConnType)
+	if err != nil {
+		ts.responseHandlers.Remove(requestID)
+		return err
+	}
+
+	if err := ts.outbound.SendRequest(tcpConn, requestID, action, request); err != nil {
+		ts.responseHandlers.Remove(requestID)
+		return &SendRequestError{Action: action, Cause: err}
+	}
+
+	return nil
+}
+
+// ConnectToNode establishes a connection to the given node.
+func (ts *TransportService) ConnectToNode(node DiscoveryNode) error {
+	return ts.connectionMgr.Connect(node)
+}
+
+// DisconnectFromNode closes the connection to the given node.
+func (ts *TransportService) DisconnectFromNode(nodeID string) {
+	ts.connectionMgr.DisconnectFromNode(nodeID)
+}
+
+// Stop shuts down the transport service.
+func (ts *TransportService) Stop() error {
+	if err := ts.connectionMgr.Close(); err != nil {
+		return err
+	}
+	if err := ts.transport.Stop(); err != nil {
+		return err
+	}
+	ts.threadPool.Shutdown()
+	return nil
+}
+
+// responseHandlerWrapper is a type-erased response callback that implements
+// the interfaces expected by InboundHandler.handleResponse.
+type responseHandlerWrapper struct {
+	executorName  string
+	readAndHandle func(in *StreamInput) error
+	onError       func(*RemoteTransportError)
+}
+
+// ReadAndHandle deserializes and handles a successful response.
+func (w *responseHandlerWrapper) ReadAndHandle(in *StreamInput) error {
+	return w.readAndHandle(in)
+}
+
+// HandleError handles an error response.
+func (w *responseHandlerWrapper) HandleError(err *RemoteTransportError) {
+	if w.onError != nil {
+		w.onError(err)
+	}
+}
+
+// TypedResponseHandler creates a type-erased response handler from typed callbacks.
+func TypedResponseHandler[T any](reader Reader[T], executor string, onResponse func(T), onError func(*RemoteTransportError)) *responseHandlerWrapper {
+	return &responseHandlerWrapper{
+		executorName: executor,
+		readAndHandle: func(in *StreamInput) error {
+			resp, err := reader(in)
+			if err != nil {
+				return err
+			}
+			onResponse(resp)
+			return nil
+		},
+		onError: onError,
+	}
+}
+
+// localTransportChannel delivers responses locally without going through TCP.
+type localTransportChannel struct {
+	handler    *responseHandlerWrapper
+	threadPool *ThreadPool
+	mu         sync.Mutex
+	responded  bool
+}
+
+// SendResponse serializes the response and delivers it to the handler.
+func (c *localTransportChannel) SendResponse(response Writeable) error {
+	c.mu.Lock()
+	if c.responded {
+		c.mu.Unlock()
+		return nil
+	}
+	c.responded = true
+	c.mu.Unlock()
+
+	var buf bytes.Buffer
+	out := NewStreamOutput(&buf)
+	if err := response.WriteTo(out); err != nil {
+		return err
+	}
+
+	in := NewStreamInput(bytes.NewReader(buf.Bytes()))
+
+	executor := c.threadPool.Get(c.handler.executorName)
+	return executor.Execute(func() {
+		c.handler.readAndHandle(in)
+	})
+}
+
+// SendError wraps the error as a RemoteTransportError and delivers it to the handler.
+func (c *localTransportChannel) SendError(err error) error {
+	c.mu.Lock()
+	if c.responded {
+		c.mu.Unlock()
+		return nil
+	}
+	c.responded = true
+	c.mu.Unlock()
+
+	rte := &RemoteTransportError{Message: err.Error()}
+	c.handler.HandleError(rte)
+	return nil
+}

--- a/server/transport/service.go
+++ b/server/transport/service.go
@@ -2,6 +2,7 @@ package transport
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -13,7 +14,7 @@ import (
 type TransportServiceConfig struct {
 	BindAddress string
 	NodeName    string
-	PoolConfigs map[string]PoolConfig
+	PoolConfigs map[PoolName]PoolConfig
 	ConnProfile ConnectionProfile // optional, uses default if zero
 }
 
@@ -24,7 +25,7 @@ type TransportService struct {
 	connectionMgr    *ConnectionManager
 	requestHandlers  *RequestHandlerMap
 	responseHandlers *ResponseHandlers
-	threadPool       *ThreadPool
+	workerPool       *WorkerPool
 	outbound         *OutboundHandler
 }
 
@@ -35,13 +36,13 @@ func NewTransportService(config TransportServiceConfig) (*TransportService, erro
 
 	requestHandlers := NewRequestHandlerMap()
 	responseHandlers := NewResponseHandlers()
-	threadPool := NewThreadPool(config.PoolConfigs)
+	workerPool := NewWorkerPool(config.PoolConfigs)
 
-	transport := NewTcpTransport(localNode, requestHandlers, responseHandlers, threadPool)
+	transport := NewTcpTransport(localNode, requestHandlers, responseHandlers, workerPool)
 
 	addr, err := transport.Start(config.BindAddress)
 	if err != nil {
-		threadPool.Shutdown()
+		workerPool.Shutdown()
 		return nil, err
 	}
 	localNode.Address = addr
@@ -62,7 +63,7 @@ func NewTransportService(config TransportServiceConfig) (*TransportService, erro
 		connectionMgr:    connectionMgr,
 		requestHandlers:  requestHandlers,
 		responseHandlers: responseHandlers,
-		threadPool:       threadPool,
+		workerPool:       workerPool,
 		outbound:         NewOutboundHandler(),
 	}, nil
 }
@@ -70,11 +71,6 @@ func NewTransportService(config TransportServiceConfig) (*TransportService, erro
 // LocalNode returns the local node info.
 func (ts *TransportService) LocalNode() DiscoveryNode {
 	return ts.localNode
-}
-
-// RegisterTypedHandler registers a typed request handler on the service.
-func RegisterTypedHandler[T any](ts *TransportService, action, executor string, reader Reader[T], handler func(T, TransportChannel) error) {
-	RegisterHandler(ts.requestHandlers, action, executor, reader, handler)
 }
 
 // SendRequest sends a request to the given node. If the node is the local node,
@@ -102,11 +98,10 @@ func (ts *TransportService) sendLocalRequest(action string, request Writeable, h
 	in := NewStreamInput(bytes.NewReader(buf.Bytes()))
 	channel := &localTransportChannel{
 		handler:    handler,
-		threadPool: ts.threadPool,
+		workerPool: ts.workerPool,
 	}
 
-	executor := ts.threadPool.Get(entry.executor)
-	return executor.Execute(func() {
+	return ts.workerPool.Submit(entry.executor, func() {
 		entry.dispatch(in, channel)
 	})
 }
@@ -117,22 +112,23 @@ func (ts *TransportService) sendRemoteRequest(node DiscoveryNode, action string,
 		return err
 	}
 
+	reqCtx, cancel := context.WithTimeout(context.Background(), options.Timeout)
 	ctx := &ResponseContext{
-		Handler:   handler,
-		Action:    action,
-		NodeID:    node.ID,
-		Timeout:   options.Timeout,
-		CreatedAt: time.Now(),
+		Handler: handler,
+		Action:  action,
+		NodeID:  node.ID,
+		Ctx:     reqCtx,
+		Cancel:  cancel,
 	}
 	requestID := ts.responseHandlers.Add(ctx)
 
-	tcpConn, err := conn.Conn(options.ConnType)
+	w, err := conn.ConnWriter(options.ConnType)
 	if err != nil {
 		ts.responseHandlers.Remove(requestID)
 		return err
 	}
 
-	if err := ts.outbound.SendRequest(tcpConn, requestID, action, request); err != nil {
+	if err := ts.outbound.SendRequest(w, requestID, action, request); err != nil {
 		ts.responseHandlers.Remove(requestID)
 		return &SendRequestError{Action: action, Cause: err}
 	}
@@ -158,14 +154,14 @@ func (ts *TransportService) Stop() error {
 	if err := ts.transport.Stop(); err != nil {
 		return err
 	}
-	ts.threadPool.Shutdown()
+	ts.workerPool.Shutdown()
 	return nil
 }
 
 // responseHandlerWrapper is a type-erased response callback that implements
 // the interfaces expected by InboundHandler.handleResponse.
 type responseHandlerWrapper struct {
-	executorName  string
+	executorName  PoolName
 	readAndHandle func(in *StreamInput) error
 	onError       func(*RemoteTransportError)
 }
@@ -183,7 +179,7 @@ func (w *responseHandlerWrapper) HandleError(err *RemoteTransportError) {
 }
 
 // TypedResponseHandler creates a type-erased response handler from typed callbacks.
-func TypedResponseHandler[T any](reader Reader[T], executor string, onResponse func(T), onError func(*RemoteTransportError)) *responseHandlerWrapper {
+func TypedResponseHandler[T any](reader Reader[T], executor PoolName, onResponse func(T), onError func(*RemoteTransportError)) *responseHandlerWrapper {
 	return &responseHandlerWrapper{
 		executorName: executor,
 		readAndHandle: func(in *StreamInput) error {
@@ -201,7 +197,7 @@ func TypedResponseHandler[T any](reader Reader[T], executor string, onResponse f
 // localTransportChannel delivers responses locally without going through TCP.
 type localTransportChannel struct {
 	handler    *responseHandlerWrapper
-	threadPool *ThreadPool
+	workerPool *WorkerPool
 	mu         sync.Mutex
 	responded  bool
 }
@@ -224,8 +220,7 @@ func (c *localTransportChannel) SendResponse(response Writeable) error {
 
 	in := NewStreamInput(bytes.NewReader(buf.Bytes()))
 
-	executor := c.threadPool.Get(c.handler.executorName)
-	return executor.Execute(func() {
+	return c.workerPool.Submit(c.handler.executorName, func() {
 		c.handler.readAndHandle(in)
 	})
 }

--- a/server/transport/service_test.go
+++ b/server/transport/service_test.go
@@ -1,0 +1,136 @@
+package transport
+
+import (
+	"testing"
+	"time"
+)
+
+type svcTestRequest struct{ Value string }
+
+func (r *svcTestRequest) WriteTo(out *StreamOutput) error { return out.WriteString(r.Value) }
+
+func readSvcTestRequest(in *StreamInput) (*svcTestRequest, error) {
+	v, err := in.ReadString()
+	return &svcTestRequest{Value: v}, err
+}
+
+type svcTestResponse struct{ Result string }
+
+func (r *svcTestResponse) WriteTo(out *StreamOutput) error { return out.WriteString(r.Result) }
+
+func readSvcTestResponse(in *StreamInput) (*svcTestResponse, error) {
+	v, err := in.ReadString()
+	return &svcTestResponse{Result: v}, err
+}
+
+func newTestTransportService(t *testing.T) *TransportService {
+	t.Helper()
+	ts, err := NewTransportService(TransportServiceConfig{
+		BindAddress: "127.0.0.1:0",
+		NodeName:    t.Name(),
+		PoolConfigs: map[string]PoolConfig{
+			"generic": {Workers: 4, QueueSize: 100},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ts.Stop() })
+	return ts
+}
+
+func TestTransportService_LocalRequest(t *testing.T) {
+	ts := newTestTransportService(t)
+
+	// Register a handler that echoes back "echo:<value>"
+	RegisterTypedHandler(ts, "test:echo", "generic",
+		readSvcTestRequest,
+		func(req *svcTestRequest, ch TransportChannel) error {
+			return ch.SendResponse(&svcTestResponse{Result: "echo:" + req.Value})
+		},
+	)
+
+	done := make(chan struct{})
+	var gotResult string
+
+	handler := TypedResponseHandler(
+		readSvcTestResponse,
+		"generic",
+		func(resp *svcTestResponse) {
+			gotResult = resp.Result
+			close(done)
+		},
+		func(err *RemoteTransportError) {
+			t.Errorf("unexpected error: %v", err)
+			close(done)
+		},
+	)
+
+	err := ts.SendRequest(ts.LocalNode(), "test:echo", &svcTestRequest{Value: "hello"}, TransportRequestOptions{}, handler)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for response")
+	}
+
+	if gotResult != "echo:hello" {
+		t.Errorf("got %q, want %q", gotResult, "echo:hello")
+	}
+}
+
+func TestTransportService_RemoteRequest(t *testing.T) {
+	// Start server
+	server := newTestTransportService(t)
+
+	// Register handler on server
+	RegisterTypedHandler(server, "test:echo", "generic",
+		readSvcTestRequest,
+		func(req *svcTestRequest, ch TransportChannel) error {
+			return ch.SendResponse(&svcTestResponse{Result: "echo:" + req.Value})
+		},
+	)
+
+	// Start client
+	client := newTestTransportService(t)
+
+	// Connect client to server
+	serverNode := server.LocalNode()
+	if err := client.ConnectToNode(serverNode); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	var gotResult string
+
+	handler := TypedResponseHandler(
+		readSvcTestResponse,
+		"generic",
+		func(resp *svcTestResponse) {
+			gotResult = resp.Result
+			close(done)
+		},
+		func(err *RemoteTransportError) {
+			t.Errorf("unexpected error: %v", err)
+			close(done)
+		},
+	)
+
+	err := client.SendRequest(serverNode, "test:echo", &svcTestRequest{Value: "world"}, TransportRequestOptions{}, handler)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for response")
+	}
+
+	if gotResult != "echo:world" {
+		t.Errorf("got %q, want %q", gotResult, "echo:world")
+	}
+}

--- a/server/transport/service_test.go
+++ b/server/transport/service_test.go
@@ -28,8 +28,8 @@ func newTestTransportService(t *testing.T) *TransportService {
 	ts, err := NewTransportService(TransportServiceConfig{
 		BindAddress: "127.0.0.1:0",
 		NodeName:    t.Name(),
-		PoolConfigs: map[string]PoolConfig{
-			"generic": {Workers: 4, QueueSize: 100},
+		PoolConfigs: map[PoolName]PoolConfig{
+			PoolGeneric: {Workers: 4, QueueSize: 100},
 		},
 	})
 	if err != nil {
@@ -43,7 +43,7 @@ func TestTransportService_LocalRequest(t *testing.T) {
 	ts := newTestTransportService(t)
 
 	// Register a handler that echoes back "echo:<value>"
-	RegisterTypedHandler(ts, "test:echo", "generic",
+	registerHandler(ts.requestHandlers, "test:echo", PoolGeneric,
 		readSvcTestRequest,
 		func(req *svcTestRequest, ch TransportChannel) error {
 			return ch.SendResponse(&svcTestResponse{Result: "echo:" + req.Value})
@@ -55,7 +55,7 @@ func TestTransportService_LocalRequest(t *testing.T) {
 
 	handler := TypedResponseHandler(
 		readSvcTestResponse,
-		"generic",
+		PoolGeneric,
 		func(resp *svcTestResponse) {
 			gotResult = resp.Result
 			close(done)
@@ -87,7 +87,7 @@ func TestTransportService_RemoteRequest(t *testing.T) {
 	server := newTestTransportService(t)
 
 	// Register handler on server
-	RegisterTypedHandler(server, "test:echo", "generic",
+	registerHandler(server.requestHandlers, "test:echo", PoolGeneric,
 		readSvcTestRequest,
 		func(req *svcTestRequest, ch TransportChannel) error {
 			return ch.SendResponse(&svcTestResponse{Result: "echo:" + req.Value})
@@ -108,7 +108,7 @@ func TestTransportService_RemoteRequest(t *testing.T) {
 
 	handler := TypedResponseHandler(
 		readSvcTestResponse,
-		"generic",
+		PoolGeneric,
 		func(resp *svcTestResponse) {
 			gotResult = resp.Result
 			close(done)

--- a/server/transport/stream.go
+++ b/server/transport/stream.go
@@ -1,0 +1,396 @@
+package transport
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+)
+
+// StreamOutput wraps an io.Writer and provides methods for writing
+// primitive types in a binary format compatible with Elasticsearch's
+// StreamOutput serialization.
+type StreamOutput struct {
+	w io.Writer
+}
+
+// NewStreamOutput creates a new StreamOutput wrapping the given writer.
+func NewStreamOutput(w io.Writer) *StreamOutput {
+	return &StreamOutput{w: w}
+}
+
+// WriteByte writes a single byte.
+func (s *StreamOutput) WriteByte(b byte) error {
+	_, err := s.w.Write([]byte{b})
+	return err
+}
+
+// WriteBytes writes a raw byte slice without any length prefix.
+func (s *StreamOutput) WriteBytes(b []byte) error {
+	_, err := s.w.Write(b)
+	return err
+}
+
+// WriteVInt writes an int32 as an unsigned varint (MSB continuation bit).
+// The value is treated as uint32 for encoding purposes.
+func (s *StreamOutput) WriteVInt(v int32) error {
+	return s.writeUvarint(uint64(uint32(v)))
+}
+
+// WriteVLong writes an int64 as an unsigned varint (MSB continuation bit).
+// The value is treated as uint64 for encoding purposes.
+func (s *StreamOutput) WriteVLong(v int64) error {
+	return s.writeUvarint(uint64(v))
+}
+
+func (s *StreamOutput) writeUvarint(v uint64) error {
+	for v >= 0x80 {
+		if err := s.WriteByte(byte(v&0x7F) | 0x80); err != nil {
+			return err
+		}
+		v >>= 7
+	}
+	return s.WriteByte(byte(v))
+}
+
+// WriteInt32 writes an int32 in big-endian fixed format.
+func (s *StreamOutput) WriteInt32(v int32) error {
+	var buf [4]byte
+	binary.BigEndian.PutUint32(buf[:], uint32(v))
+	_, err := s.w.Write(buf[:])
+	return err
+}
+
+// WriteInt64 writes an int64 in big-endian fixed format.
+func (s *StreamOutput) WriteInt64(v int64) error {
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], uint64(v))
+	_, err := s.w.Write(buf[:])
+	return err
+}
+
+// WriteFloat64 writes a float64 by converting it to uint64 bits and writing as int64.
+func (s *StreamOutput) WriteFloat64(v float64) error {
+	return s.WriteInt64(int64(math.Float64bits(v)))
+}
+
+// WriteBool writes a boolean as a single byte (1=true, 0=false).
+func (s *StreamOutput) WriteBool(v bool) error {
+	if v {
+		return s.WriteByte(1)
+	}
+	return s.WriteByte(0)
+}
+
+// WriteString writes a string as a VInt length prefix followed by UTF-8 bytes.
+func (s *StreamOutput) WriteString(v string) error {
+	b := []byte(v)
+	if err := s.WriteVInt(int32(len(b))); err != nil {
+		return err
+	}
+	return s.WriteBytes(b)
+}
+
+// WriteByteArray writes a byte slice as a VInt length prefix followed by raw bytes.
+func (s *StreamOutput) WriteByteArray(b []byte) error {
+	if err := s.WriteVInt(int32(len(b))); err != nil {
+		return err
+	}
+	return s.WriteBytes(b)
+}
+
+// WriteOptionalInt64 writes an optional int64 with a 1-byte presence flag.
+// If v is nil, writes false. Otherwise writes true followed by the VLong value.
+func (s *StreamOutput) WriteOptionalInt64(v *int64) error {
+	if v == nil {
+		return s.WriteBool(false)
+	}
+	if err := s.WriteBool(true); err != nil {
+		return err
+	}
+	return s.WriteVLong(*v)
+}
+
+// GenericMap type tags.
+const (
+	tagNil     byte = 0
+	tagString  byte = 1
+	tagInt64   byte = 2
+	tagFloat64 byte = 3
+	tagBool    byte = 4
+	tagMap     byte = 5
+	tagSlice   byte = 6
+)
+
+// WriteGenericMap writes a map[string]any with type-tagged values.
+// Nil maps are encoded with presence=false.
+func (s *StreamOutput) WriteGenericMap(m map[string]any) error {
+	if m == nil {
+		return s.WriteBool(false)
+	}
+	if err := s.WriteBool(true); err != nil {
+		return err
+	}
+	if err := s.WriteVInt(int32(len(m))); err != nil {
+		return err
+	}
+	for k, v := range m {
+		if err := s.WriteString(k); err != nil {
+			return err
+		}
+		if err := s.writeGenericValue(v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *StreamOutput) writeGenericValue(v any) error {
+	if v == nil {
+		return s.WriteByte(tagNil)
+	}
+	switch val := v.(type) {
+	case string:
+		if err := s.WriteByte(tagString); err != nil {
+			return err
+		}
+		return s.WriteString(val)
+	case int64:
+		if err := s.WriteByte(tagInt64); err != nil {
+			return err
+		}
+		return s.WriteVLong(val)
+	case float64:
+		if err := s.WriteByte(tagFloat64); err != nil {
+			return err
+		}
+		return s.WriteFloat64(val)
+	case bool:
+		if err := s.WriteByte(tagBool); err != nil {
+			return err
+		}
+		return s.WriteBool(val)
+	case map[string]any:
+		if err := s.WriteByte(tagMap); err != nil {
+			return err
+		}
+		return s.WriteGenericMap(val)
+	case []any:
+		if err := s.WriteByte(tagSlice); err != nil {
+			return err
+		}
+		if err := s.WriteVInt(int32(len(val))); err != nil {
+			return err
+		}
+		for _, elem := range val {
+			if err := s.writeGenericValue(elem); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported generic value type: %T", v)
+	}
+}
+
+// StreamInput wraps an io.Reader and provides methods for reading
+// primitive types serialized by StreamOutput.
+type StreamInput struct {
+	r io.Reader
+}
+
+// NewStreamInput creates a new StreamInput wrapping the given reader.
+func NewStreamInput(r io.Reader) *StreamInput {
+	return &StreamInput{r: r}
+}
+
+// ReadByte reads a single byte.
+func (s *StreamInput) ReadByte() (byte, error) {
+	var buf [1]byte
+	_, err := io.ReadFull(s.r, buf[:])
+	return buf[0], err
+}
+
+// ReadBytes reads exactly n bytes.
+func (s *StreamInput) ReadBytes(n int) ([]byte, error) {
+	buf := make([]byte, n)
+	_, err := io.ReadFull(s.r, buf)
+	return buf, err
+}
+
+// ReadVInt reads an unsigned varint and returns it as int32.
+func (s *StreamInput) ReadVInt() (int32, error) {
+	v, err := s.readUvarint()
+	if err != nil {
+		return 0, err
+	}
+	return int32(uint32(v)), nil
+}
+
+// ReadVLong reads an unsigned varint and returns it as int64.
+func (s *StreamInput) ReadVLong() (int64, error) {
+	v, err := s.readUvarint()
+	if err != nil {
+		return 0, err
+	}
+	return int64(v), nil
+}
+
+func (s *StreamInput) readUvarint() (uint64, error) {
+	var result uint64
+	var shift uint
+	for {
+		b, err := s.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+		result |= uint64(b&0x7F) << shift
+		if b&0x80 == 0 {
+			break
+		}
+		shift += 7
+		if shift >= 64 {
+			return 0, fmt.Errorf("varint overflow")
+		}
+	}
+	return result, nil
+}
+
+// ReadInt32 reads a big-endian fixed int32.
+func (s *StreamInput) ReadInt32() (int32, error) {
+	buf, err := s.ReadBytes(4)
+	if err != nil {
+		return 0, err
+	}
+	return int32(binary.BigEndian.Uint32(buf)), nil
+}
+
+// ReadInt64 reads a big-endian fixed int64.
+func (s *StreamInput) ReadInt64() (int64, error) {
+	buf, err := s.ReadBytes(8)
+	if err != nil {
+		return 0, err
+	}
+	return int64(binary.BigEndian.Uint64(buf)), nil
+}
+
+// ReadFloat64 reads a float64 (stored as int64 bits).
+func (s *StreamInput) ReadFloat64() (float64, error) {
+	v, err := s.ReadInt64()
+	if err != nil {
+		return 0, err
+	}
+	return math.Float64frombits(uint64(v)), nil
+}
+
+// ReadBool reads a boolean (1 byte: 1=true, 0=false).
+func (s *StreamInput) ReadBool() (bool, error) {
+	b, err := s.ReadByte()
+	if err != nil {
+		return false, err
+	}
+	return b != 0, nil
+}
+
+// ReadString reads a VInt length-prefixed UTF-8 string.
+func (s *StreamInput) ReadString() (string, error) {
+	length, err := s.ReadVInt()
+	if err != nil {
+		return "", err
+	}
+	buf, err := s.ReadBytes(int(length))
+	if err != nil {
+		return "", err
+	}
+	return string(buf), nil
+}
+
+// ReadByteArray reads a VInt length-prefixed byte array.
+func (s *StreamInput) ReadByteArray() ([]byte, error) {
+	length, err := s.ReadVInt()
+	if err != nil {
+		return nil, err
+	}
+	return s.ReadBytes(int(length))
+}
+
+// ReadOptionalInt64 reads an optional int64 with a presence flag.
+func (s *StreamInput) ReadOptionalInt64() (*int64, error) {
+	present, err := s.ReadBool()
+	if err != nil {
+		return nil, err
+	}
+	if !present {
+		return nil, nil
+	}
+	v, err := s.ReadVLong()
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+// ReadGenericMap reads a type-tagged map[string]any.
+func (s *StreamInput) ReadGenericMap() (map[string]any, error) {
+	present, err := s.ReadBool()
+	if err != nil {
+		return nil, err
+	}
+	if !present {
+		return nil, nil
+	}
+	count, err := s.ReadVInt()
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[string]any, count)
+	for range count {
+		key, err := s.ReadString()
+		if err != nil {
+			return nil, err
+		}
+		val, err := s.readGenericValue()
+		if err != nil {
+			return nil, err
+		}
+		m[key] = val
+	}
+	return m, nil
+}
+
+func (s *StreamInput) readGenericValue() (any, error) {
+	tag, err := s.ReadByte()
+	if err != nil {
+		return nil, err
+	}
+	switch tag {
+	case tagNil:
+		return nil, nil
+	case tagString:
+		return s.ReadString()
+	case tagInt64:
+		return s.ReadVLong()
+	case tagFloat64:
+		return s.ReadFloat64()
+	case tagBool:
+		return s.ReadBool()
+	case tagMap:
+		return s.ReadGenericMap()
+	case tagSlice:
+		length, err := s.ReadVInt()
+		if err != nil {
+			return nil, err
+		}
+		slice := make([]any, length)
+		for i := range length {
+			v, err := s.readGenericValue()
+			if err != nil {
+				return nil, err
+			}
+			slice[i] = v
+		}
+		return slice, nil
+	default:
+		return nil, fmt.Errorf("unknown generic value tag: %d", tag)
+	}
+}

--- a/server/transport/stream_test.go
+++ b/server/transport/stream_test.go
@@ -1,0 +1,319 @@
+package transport
+
+import (
+	"bytes"
+	"math"
+	"testing"
+)
+
+func TestWriteReadByte(t *testing.T) {
+	var buf bytes.Buffer
+	out := NewStreamOutput(&buf)
+	if err := out.WriteByte(0xAB); err != nil {
+		t.Fatal(err)
+	}
+	in := NewStreamInput(&buf)
+	got, err := in.ReadByte()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 0xAB {
+		t.Fatalf("expected 0xAB, got 0x%02X", got)
+	}
+}
+
+func TestWriteReadBytes(t *testing.T) {
+	var buf bytes.Buffer
+	out := NewStreamOutput(&buf)
+	data := []byte{1, 2, 3, 4, 5}
+	if err := out.WriteBytes(data); err != nil {
+		t.Fatal(err)
+	}
+	in := NewStreamInput(&buf)
+	got, err := in.ReadBytes(5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("expected %v, got %v", data, got)
+	}
+}
+
+func TestWriteVIntEncoding(t *testing.T) {
+	tests := []struct {
+		name  string
+		value int32
+		want  []byte
+	}{
+		{"zero", 0, []byte{0x00}},
+		{"42", 42, []byte{42}},
+		{"127", 127, []byte{127}},
+		{"128", 128, []byte{0x80, 0x01}},
+		{"16384", 16384, []byte{0x80, 0x80, 0x01}},
+		{"-1", -1, []byte{0xFF, 0xFF, 0xFF, 0xFF, 0x0F}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			out := NewStreamOutput(&buf)
+			if err := out.WriteVInt(tt.value); err != nil {
+				t.Fatal(err)
+			}
+			got := buf.Bytes()
+			if !bytes.Equal(got, tt.want) {
+				t.Fatalf("WriteVInt(%d): got %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWriteVLongEncoding(t *testing.T) {
+	tests := []struct {
+		name  string
+		value int64
+		want  []byte
+	}{
+		{"300", 300, []byte{0xAC, 0x02}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			out := NewStreamOutput(&buf)
+			if err := out.WriteVLong(tt.value); err != nil {
+				t.Fatal(err)
+			}
+			got := buf.Bytes()
+			if !bytes.Equal(got, tt.want) {
+				t.Fatalf("WriteVLong(%d): got %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWriteReadString(t *testing.T) {
+	var buf bytes.Buffer
+	out := NewStreamOutput(&buf)
+	if err := out.WriteString("hello"); err != nil {
+		t.Fatal(err)
+	}
+	in := NewStreamInput(&buf)
+	got, err := in.ReadString()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "hello" {
+		t.Fatalf("expected %q, got %q", "hello", got)
+	}
+}
+
+func TestWriteReadBool(t *testing.T) {
+	for _, v := range []bool{true, false} {
+		var buf bytes.Buffer
+		out := NewStreamOutput(&buf)
+		if err := out.WriteBool(v); err != nil {
+			t.Fatal(err)
+		}
+		in := NewStreamInput(&buf)
+		got, err := in.ReadBool()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != v {
+			t.Fatalf("expected %v, got %v", v, got)
+		}
+	}
+}
+
+func TestWriteReadByteArray(t *testing.T) {
+	data := []byte(`{"key":"value"}`)
+	var buf bytes.Buffer
+	out := NewStreamOutput(&buf)
+	if err := out.WriteByteArray(data); err != nil {
+		t.Fatal(err)
+	}
+	in := NewStreamInput(&buf)
+	got, err := in.ReadByteArray()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("expected %v, got %v", data, got)
+	}
+}
+
+func TestWriteReadOptionalInt64(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		var buf bytes.Buffer
+		out := NewStreamOutput(&buf)
+		v := int64(42)
+		if err := out.WriteOptionalInt64(&v); err != nil {
+			t.Fatal(err)
+		}
+		in := NewStreamInput(&buf)
+		got, err := in.ReadOptionalInt64()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got == nil || *got != 42 {
+			t.Fatalf("expected 42, got %v", got)
+		}
+	})
+	t.Run("nil", func(t *testing.T) {
+		var buf bytes.Buffer
+		out := NewStreamOutput(&buf)
+		if err := out.WriteOptionalInt64(nil); err != nil {
+			t.Fatal(err)
+		}
+		in := NewStreamInput(&buf)
+		got, err := in.ReadOptionalInt64()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != nil {
+			t.Fatalf("expected nil, got %v", *got)
+		}
+	})
+}
+
+func TestVIntRoundtrip(t *testing.T) {
+	values := []int32{0, 1, 127, 128, 255, 256, 16383, 16384, -1, -128, math.MaxInt32, math.MinInt32}
+	for _, v := range values {
+		var buf bytes.Buffer
+		out := NewStreamOutput(&buf)
+		if err := out.WriteVInt(v); err != nil {
+			t.Fatalf("WriteVInt(%d): %v", v, err)
+		}
+		in := NewStreamInput(&buf)
+		got, err := in.ReadVInt()
+		if err != nil {
+			t.Fatalf("ReadVInt for %d: %v", v, err)
+		}
+		if got != v {
+			t.Fatalf("VInt roundtrip: wrote %d, got %d", v, got)
+		}
+	}
+}
+
+func TestVLongRoundtrip(t *testing.T) {
+	values := []int64{0, 1, 127, 128, 300, -1, math.MaxInt64, math.MinInt64}
+	for _, v := range values {
+		var buf bytes.Buffer
+		out := NewStreamOutput(&buf)
+		if err := out.WriteVLong(v); err != nil {
+			t.Fatalf("WriteVLong(%d): %v", v, err)
+		}
+		in := NewStreamInput(&buf)
+		got, err := in.ReadVLong()
+		if err != nil {
+			t.Fatalf("ReadVLong for %d: %v", v, err)
+		}
+		if got != v {
+			t.Fatalf("VLong roundtrip: wrote %d, got %d", v, got)
+		}
+	}
+}
+
+func TestFloat64Roundtrip(t *testing.T) {
+	values := []float64{0, 1.5, -3.14, math.MaxFloat64, math.SmallestNonzeroFloat64}
+	for _, v := range values {
+		var buf bytes.Buffer
+		out := NewStreamOutput(&buf)
+		if err := out.WriteFloat64(v); err != nil {
+			t.Fatalf("WriteFloat64(%v): %v", v, err)
+		}
+		in := NewStreamInput(&buf)
+		got, err := in.ReadFloat64()
+		if err != nil {
+			t.Fatalf("ReadFloat64 for %v: %v", v, err)
+		}
+		if got != v {
+			t.Fatalf("Float64 roundtrip: wrote %v, got %v", v, got)
+		}
+	}
+}
+
+func TestGenericMapRoundtrip(t *testing.T) {
+	m := map[string]any{
+		"name":    "test",
+		"count":   int64(42),
+		"score":   float64(3.14),
+		"active":  true,
+		"nothing": nil,
+		"tags":    []any{"a", "b", int64(3)},
+		"nested": map[string]any{
+			"inner": "value",
+			"deep": map[string]any{
+				"level": int64(2),
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	out := NewStreamOutput(&buf)
+	if err := out.WriteGenericMap(m); err != nil {
+		t.Fatal(err)
+	}
+
+	in := NewStreamInput(&buf)
+	got, err := in.ReadGenericMap()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify each field
+	if got["name"] != "test" {
+		t.Fatalf("name: expected %q, got %v", "test", got["name"])
+	}
+	if got["count"] != int64(42) {
+		t.Fatalf("count: expected 42, got %v", got["count"])
+	}
+	if got["score"] != float64(3.14) {
+		t.Fatalf("score: expected 3.14, got %v", got["score"])
+	}
+	if got["active"] != true {
+		t.Fatalf("active: expected true, got %v", got["active"])
+	}
+	if got["nothing"] != nil {
+		t.Fatalf("nothing: expected nil, got %v", got["nothing"])
+	}
+
+	tags, ok := got["tags"].([]any)
+	if !ok {
+		t.Fatalf("tags: expected []any, got %T", got["tags"])
+	}
+	if len(tags) != 3 || tags[0] != "a" || tags[1] != "b" || tags[2] != int64(3) {
+		t.Fatalf("tags: unexpected value %v", tags)
+	}
+
+	nested, ok := got["nested"].(map[string]any)
+	if !ok {
+		t.Fatalf("nested: expected map[string]any, got %T", got["nested"])
+	}
+	if nested["inner"] != "value" {
+		t.Fatalf("nested.inner: expected %q, got %v", "value", nested["inner"])
+	}
+	deep, ok := nested["deep"].(map[string]any)
+	if !ok {
+		t.Fatalf("nested.deep: expected map[string]any, got %T", nested["deep"])
+	}
+	if deep["level"] != int64(2) {
+		t.Fatalf("nested.deep.level: expected 2, got %v", deep["level"])
+	}
+}
+
+func TestGenericMapNilRoundtrip(t *testing.T) {
+	var buf bytes.Buffer
+	out := NewStreamOutput(&buf)
+	if err := out.WriteGenericMap(nil); err != nil {
+		t.Fatal(err)
+	}
+
+	in := NewStreamInput(&buf)
+	got, err := in.ReadGenericMap()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil map, got %v", got)
+	}
+}

--- a/server/transport/tcp_transport.go
+++ b/server/transport/tcp_transport.go
@@ -195,8 +195,8 @@ func (t *TcpTransport) OpenConnection(node DiscoveryNode, profile ConnectionProf
 
 func (t *TcpTransport) performHandshake(conn net.Conn, profile ConnectionProfile) (int32, error) {
 	if profile.HandshakeTimeout > 0 {
-		conn.SetDeadline(deadlineFromTimeout(profile.HandshakeTimeout))
-		defer conn.SetDeadline(zeroTime)
+		conn.SetDeadline(time.Now().Add(profile.HandshakeTimeout))
+		defer conn.SetDeadline(time.Time{})
 	}
 
 	req := &HandshakeRequest{Version: CurrentTransportVersion}

--- a/server/transport/tcp_transport.go
+++ b/server/transport/tcp_transport.go
@@ -190,6 +190,18 @@ func (t *TcpTransport) OpenConnection(node DiscoveryNode, profile ConnectionProf
 		version:  negotiatedVersion,
 		counters: counters,
 	}
+
+	// Start read loops on outbound connections to receive responses.
+	for _, conns := range channels {
+		for _, conn := range conns {
+			t.wg.Add(1)
+			go func(c net.Conn) {
+				defer t.wg.Done()
+				t.handleConn(c)
+			}(conn)
+		}
+	}
+
 	return nc, nil
 }
 

--- a/server/transport/tcp_transport.go
+++ b/server/transport/tcp_transport.go
@@ -1,7 +1,9 @@
 package transport
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -14,34 +16,41 @@ func deadlineFromTimeout(d time.Duration) time.Time {
 	return time.Now().Add(d)
 }
 
-// NodeConnection holds all TCP connections to a single remote node.
-type NodeConnection struct {
-	node     DiscoveryNode
-	channels map[ConnectionType][]net.Conn
-	version  int32 // negotiated transport version
-	closed   atomic.Bool
-	counters map[ConnectionType]*atomic.Uint64 // round-robin counters
+// writerPool is a round-robin pool of mutex-guarded writers.
+type writerPool struct {
+	writers []*SyncWriter
+	counter atomic.Uint64
 }
 
-// Conn round-robins within the pool for the given type.
+func (p *writerPool) next() *SyncWriter {
+	idx := p.counter.Add(1) - 1
+	return p.writers[idx%uint64(len(p.writers))]
+}
+
+// NodeConnection holds all TCP connections to a single remote node.
+type NodeConnection struct {
+	node    DiscoveryNode
+	pools   map[ConnectionType]*writerPool
+	version int32 // negotiated transport version
+	closed  atomic.Bool
+}
+
+// ConnWriter round-robins within the pool for the given type and returns
+// a mutex-guarded writer that serializes writes to the underlying connection.
 // Falls back to ConnTypeREG if the requested type has no connections.
-func (nc *NodeConnection) Conn(ct ConnectionType) (net.Conn, error) {
+func (nc *NodeConnection) ConnWriter(ct ConnectionType) (io.Writer, error) {
 	if nc.closed.Load() {
 		return nil, fmt.Errorf("node connection closed")
 	}
-	conns := nc.channels[ct]
-	if len(conns) == 0 {
-		conns = nc.channels[ConnTypeREG]
+	pool := nc.pools[ct]
+	if pool == nil || len(pool.writers) == 0 {
+		ct = ConnTypeREG
+		pool = nc.pools[ct]
 	}
-	if len(conns) == 0 {
+	if pool == nil || len(pool.writers) == 0 {
 		return nil, fmt.Errorf("no connections available for type %d", ct)
 	}
-	counter := nc.counters[ct]
-	if counter == nil {
-		counter = nc.counters[ConnTypeREG]
-	}
-	idx := counter.Add(1) - 1
-	return conns[idx%uint64(len(conns))], nil
+	return pool.next(), nil
 }
 
 // Close closes all connections in the NodeConnection.
@@ -50,9 +59,9 @@ func (nc *NodeConnection) Close() error {
 		return nil
 	}
 	var firstErr error
-	for _, conns := range nc.channels {
-		for _, c := range conns {
-			if err := c.Close(); err != nil && firstErr == nil {
+	for _, p := range nc.pools {
+		for _, w := range p.writers {
+			if err := w.Close(); err != nil && firstErr == nil {
 				firstErr = err
 			}
 		}
@@ -66,7 +75,7 @@ type TcpTransport struct {
 	listener         net.Listener
 	requestHandlers  *RequestHandlerMap
 	responseHandlers *ResponseHandlers
-	threadPool       *ThreadPool
+	workerPool       *WorkerPool
 	outbound         *OutboundHandler
 	inbound          *InboundHandler
 	stopCh           chan struct{}
@@ -74,14 +83,14 @@ type TcpTransport struct {
 }
 
 // NewTcpTransport creates a new TcpTransport.
-func NewTcpTransport(localNode DiscoveryNode, requestHandlers *RequestHandlerMap, responseHandlers *ResponseHandlers, threadPool *ThreadPool) *TcpTransport {
+func NewTcpTransport(localNode DiscoveryNode, requestHandlers *RequestHandlerMap, responseHandlers *ResponseHandlers, workerPool *WorkerPool) *TcpTransport {
 	return &TcpTransport{
 		localNode:        localNode,
 		requestHandlers:  requestHandlers,
 		responseHandlers: responseHandlers,
-		threadPool:       threadPool,
+		workerPool:       workerPool,
 		outbound:         NewOutboundHandler(),
-		inbound:          NewInboundHandler(requestHandlers, responseHandlers, threadPool, localNode.ID),
+		inbound:          NewInboundHandler(requestHandlers, responseHandlers, workerPool, localNode.ID),
 		stopCh:           make(chan struct{}),
 	}
 }
@@ -134,13 +143,14 @@ func (t *TcpTransport) acceptLoop() {
 }
 
 func (t *TcpTransport) handleConn(conn net.Conn) {
+	w := NewSyncWriter(conn)
 	for {
 		select {
 		case <-t.stopCh:
 			return
 		default:
 		}
-		if err := t.inbound.HandleMessage(conn, conn); err != nil {
+		if err := t.inbound.HandleMessage(conn, w); err != nil {
 			return
 		}
 	}
@@ -149,8 +159,7 @@ func (t *TcpTransport) handleConn(conn net.Conn) {
 // OpenConnection dials TCP connections per the profile, performs handshake on each,
 // and returns a NodeConnection. On any failure, closes all already-opened connections.
 func (t *TcpTransport) OpenConnection(node DiscoveryNode, profile ConnectionProfile) (*NodeConnection, error) {
-	channels := make(map[ConnectionType][]net.Conn)
-	counters := make(map[ConnectionType]*atomic.Uint64)
+	pools := make(map[ConnectionType]*writerPool)
 	var allConns []net.Conn
 
 	cleanup := func() {
@@ -159,10 +168,8 @@ func (t *TcpTransport) OpenConnection(node DiscoveryNode, profile ConnectionProf
 		}
 	}
 
-	var negotiatedVersion int32
-
 	for ct, count := range profile.ConnPerType {
-		conns := make([]net.Conn, 0, count)
+		cw := make([]*SyncWriter, 0, count)
 		for range count {
 			conn, err := net.DialTimeout("tcp", node.Address, profile.ConnectTimeout)
 			if err != nil {
@@ -170,36 +177,34 @@ func (t *TcpTransport) OpenConnection(node DiscoveryNode, profile ConnectionProf
 				return nil, fmt.Errorf("dial %s: %w", node.Address, err)
 			}
 			allConns = append(allConns, conn)
-
-			version, err := t.performHandshake(conn, profile)
-			if err != nil {
-				cleanup()
-				return nil, fmt.Errorf("handshake with %s: %w", node.Address, err)
-			}
-			negotiatedVersion = version
-
-			conns = append(conns, conn)
+			cw = append(cw, NewSyncWriter(conn))
 		}
-		channels[ct] = conns
-		counters[ct] = &atomic.Uint64{}
+		pools[ct] = &writerPool{writers: cw}
+	}
+
+	if len(allConns) == 0 {
+		return nil, fmt.Errorf("no connections configured for %s", node.Address)
+	}
+
+	version, err := t.performHandshake(allConns[0], profile)
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("handshake with %s: %w", node.Address, err)
 	}
 
 	nc := &NodeConnection{
-		node:     node,
-		channels: channels,
-		version:  negotiatedVersion,
-		counters: counters,
+		node:    node,
+		pools:   pools,
+		version: version,
 	}
 
 	// Start read loops on outbound connections to receive responses.
-	for _, conns := range channels {
-		for _, conn := range conns {
-			t.wg.Add(1)
-			go func(c net.Conn) {
-				defer t.wg.Done()
-				t.handleConn(c)
-			}(conn)
-		}
+	for _, conn := range allConns {
+		t.wg.Add(1)
+		go func(c net.Conn) {
+			defer t.wg.Done()
+			t.handleConn(c)
+		}(conn)
 	}
 
 	return nc, nil
@@ -229,7 +234,7 @@ func (t *TcpTransport) performHandshake(conn net.Conn, profile ConnectionProfile
 		return 0, fmt.Errorf("read handshake response payload: %w", err)
 	}
 
-	in := NewStreamInput(&bufferReader{buf: payloadBytes})
+	in := NewStreamInput(bytes.NewReader(payloadBytes))
 	resp, err := ReadHandshakeResponse(in)
 	if err != nil {
 		return 0, fmt.Errorf("decode handshake response: %w", err)

--- a/server/transport/tcp_transport.go
+++ b/server/transport/tcp_transport.go
@@ -1,0 +1,227 @@
+package transport
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+var zeroTime time.Time
+
+func deadlineFromTimeout(d time.Duration) time.Time {
+	return time.Now().Add(d)
+}
+
+// NodeConnection holds all TCP connections to a single remote node.
+type NodeConnection struct {
+	node     DiscoveryNode
+	channels map[ConnectionType][]net.Conn
+	version  int32 // negotiated transport version
+	closed   atomic.Bool
+	counters map[ConnectionType]*atomic.Uint64 // round-robin counters
+}
+
+// Conn round-robins within the pool for the given type.
+// Falls back to ConnTypeREG if the requested type has no connections.
+func (nc *NodeConnection) Conn(ct ConnectionType) (net.Conn, error) {
+	if nc.closed.Load() {
+		return nil, fmt.Errorf("node connection closed")
+	}
+	conns := nc.channels[ct]
+	if len(conns) == 0 {
+		conns = nc.channels[ConnTypeREG]
+	}
+	if len(conns) == 0 {
+		return nil, fmt.Errorf("no connections available for type %d", ct)
+	}
+	counter := nc.counters[ct]
+	if counter == nil {
+		counter = nc.counters[ConnTypeREG]
+	}
+	idx := counter.Add(1) - 1
+	return conns[idx%uint64(len(conns))], nil
+}
+
+// Close closes all connections in the NodeConnection.
+func (nc *NodeConnection) Close() error {
+	if !nc.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+	var firstErr error
+	for _, conns := range nc.channels {
+		for _, c := range conns {
+			if err := c.Close(); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	return firstErr
+}
+
+// TcpTransport manages TCP listening and connection establishment.
+type TcpTransport struct {
+	localNode        DiscoveryNode
+	listener         net.Listener
+	requestHandlers  *RequestHandlerMap
+	responseHandlers *ResponseHandlers
+	threadPool       *ThreadPool
+	outbound         *OutboundHandler
+	inbound          *InboundHandler
+	stopCh           chan struct{}
+	wg               sync.WaitGroup
+}
+
+// NewTcpTransport creates a new TcpTransport.
+func NewTcpTransport(localNode DiscoveryNode, requestHandlers *RequestHandlerMap, responseHandlers *ResponseHandlers, threadPool *ThreadPool) *TcpTransport {
+	return &TcpTransport{
+		localNode:        localNode,
+		requestHandlers:  requestHandlers,
+		responseHandlers: responseHandlers,
+		threadPool:       threadPool,
+		outbound:         NewOutboundHandler(),
+		inbound:          NewInboundHandler(requestHandlers, responseHandlers, threadPool, localNode.ID),
+		stopCh:           make(chan struct{}),
+	}
+}
+
+// Start starts the TCP listener and spawns the accept loop goroutine.
+// Returns the bound address.
+func (t *TcpTransport) Start(bindAddress string) (string, error) {
+	ln, err := net.Listen("tcp", bindAddress)
+	if err != nil {
+		return "", fmt.Errorf("listen on %s: %w", bindAddress, err)
+	}
+	t.listener = ln
+
+	t.wg.Add(1)
+	go t.acceptLoop()
+
+	return ln.Addr().String(), nil
+}
+
+// Stop closes the stop channel, closes the listener, and waits for all goroutines.
+func (t *TcpTransport) Stop() error {
+	close(t.stopCh)
+	var err error
+	if t.listener != nil {
+		err = t.listener.Close()
+	}
+	t.wg.Wait()
+	return err
+}
+
+func (t *TcpTransport) acceptLoop() {
+	defer t.wg.Done()
+	for {
+		conn, err := t.listener.Accept()
+		if err != nil {
+			select {
+			case <-t.stopCh:
+				return
+			default:
+				continue
+			}
+		}
+		t.wg.Add(1)
+		go func(c net.Conn) {
+			defer t.wg.Done()
+			defer c.Close()
+			t.handleConn(c)
+		}(conn)
+	}
+}
+
+func (t *TcpTransport) handleConn(conn net.Conn) {
+	for {
+		select {
+		case <-t.stopCh:
+			return
+		default:
+		}
+		if err := t.inbound.HandleMessage(conn, conn); err != nil {
+			return
+		}
+	}
+}
+
+// OpenConnection dials TCP connections per the profile, performs handshake on each,
+// and returns a NodeConnection. On any failure, closes all already-opened connections.
+func (t *TcpTransport) OpenConnection(node DiscoveryNode, profile ConnectionProfile) (*NodeConnection, error) {
+	channels := make(map[ConnectionType][]net.Conn)
+	counters := make(map[ConnectionType]*atomic.Uint64)
+	var allConns []net.Conn
+
+	cleanup := func() {
+		for _, c := range allConns {
+			c.Close()
+		}
+	}
+
+	var negotiatedVersion int32
+
+	for ct, count := range profile.ConnPerType {
+		conns := make([]net.Conn, 0, count)
+		for range count {
+			conn, err := net.DialTimeout("tcp", node.Address, profile.ConnectTimeout)
+			if err != nil {
+				cleanup()
+				return nil, fmt.Errorf("dial %s: %w", node.Address, err)
+			}
+			allConns = append(allConns, conn)
+
+			version, err := t.performHandshake(conn, profile)
+			if err != nil {
+				cleanup()
+				return nil, fmt.Errorf("handshake with %s: %w", node.Address, err)
+			}
+			negotiatedVersion = version
+
+			conns = append(conns, conn)
+		}
+		channels[ct] = conns
+		counters[ct] = &atomic.Uint64{}
+	}
+
+	nc := &NodeConnection{
+		node:     node,
+		channels: channels,
+		version:  negotiatedVersion,
+		counters: counters,
+	}
+	return nc, nil
+}
+
+func (t *TcpTransport) performHandshake(conn net.Conn, profile ConnectionProfile) (int32, error) {
+	if profile.HandshakeTimeout > 0 {
+		conn.SetDeadline(deadlineFromTimeout(profile.HandshakeTimeout))
+		defer conn.SetDeadline(zeroTime)
+	}
+
+	req := &HandshakeRequest{Version: CurrentTransportVersion}
+	if err := t.outbound.SendHandshakeRequest(conn, 0, req); err != nil {
+		return 0, fmt.Errorf("send handshake request: %w", err)
+	}
+
+	header, err := ReadHeader(conn)
+	if err != nil {
+		return 0, fmt.Errorf("read handshake response header: %w", err)
+	}
+	if !header.Status.IsHandshake() {
+		return 0, fmt.Errorf("expected handshake response, got status %d", header.Status)
+	}
+
+	payloadBytes, err := readPayload(conn, header)
+	if err != nil {
+		return 0, fmt.Errorf("read handshake response payload: %w", err)
+	}
+
+	in := NewStreamInput(&bufferReader{buf: payloadBytes})
+	resp, err := ReadHandshakeResponse(in)
+	if err != nil {
+		return 0, fmt.Errorf("decode handshake response: %w", err)
+	}
+
+	return NegotiateVersion(CurrentTransportVersion, resp.Version), nil
+}

--- a/server/transport/tcp_transport_test.go
+++ b/server/transport/tcp_transport_test.go
@@ -1,0 +1,76 @@
+package transport
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTcpTransport_ListenAndConnect(t *testing.T) {
+	node := DiscoveryNode{ID: "node-1", Name: "test-node", Address: "127.0.0.1:0"}
+	handlers := NewRequestHandlerMap()
+	respHandlers := NewResponseHandlers()
+	tp := NewThreadPool(map[string]PoolConfig{"generic": {Workers: 0}})
+	defer tp.Shutdown()
+
+	transport := NewTcpTransport(node, handlers, respHandlers, tp)
+
+	addr, err := transport.Start("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	if addr == "" {
+		t.Fatal("expected non-empty address")
+	}
+	t.Logf("listening on %s", addr)
+
+	if err := transport.Stop(); err != nil {
+		t.Fatalf("Stop failed: %v", err)
+	}
+}
+
+func TestTcpTransport_Handshake(t *testing.T) {
+	// Server transport
+	serverNode := DiscoveryNode{ID: "server-1", Name: "server", Address: "127.0.0.1:0"}
+	handlers := NewRequestHandlerMap()
+	respHandlers := NewResponseHandlers()
+	tp := NewThreadPool(map[string]PoolConfig{"generic": {Workers: 0}})
+	defer tp.Shutdown()
+
+	server := NewTcpTransport(serverNode, handlers, respHandlers, tp)
+
+	addr, err := server.Start("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("server Start failed: %v", err)
+	}
+	defer server.Stop()
+
+	// Client transport
+	clientNode := DiscoveryNode{ID: "client-1", Name: "client", Address: "127.0.0.1:0"}
+	client := NewTcpTransport(clientNode, handlers, respHandlers, tp)
+
+	profile := ConnectionProfile{
+		ConnPerType:      map[ConnectionType]int{ConnTypeREG: 1},
+		ConnectTimeout:   5 * time.Second,
+		HandshakeTimeout: 5 * time.Second,
+	}
+
+	remoteNode := DiscoveryNode{ID: "server-1", Name: "server", Address: addr}
+	nc, err := client.OpenConnection(remoteNode, profile)
+	if err != nil {
+		t.Fatalf("OpenConnection failed: %v", err)
+	}
+	defer nc.Close()
+
+	if nc.version != CurrentTransportVersion {
+		t.Fatalf("expected negotiated version %d, got %d", CurrentTransportVersion, nc.version)
+	}
+
+	// Verify we can get a connection
+	conn, err := nc.Conn(ConnTypeREG)
+	if err != nil {
+		t.Fatalf("Conn(REG) failed: %v", err)
+	}
+	if conn == nil {
+		t.Fatal("expected non-nil connection")
+	}
+}

--- a/server/transport/tcp_transport_test.go
+++ b/server/transport/tcp_transport_test.go
@@ -9,10 +9,10 @@ func TestTcpTransport_ListenAndConnect(t *testing.T) {
 	node := DiscoveryNode{ID: "node-1", Name: "test-node", Address: "127.0.0.1:0"}
 	handlers := NewRequestHandlerMap()
 	respHandlers := NewResponseHandlers()
-	tp := NewThreadPool(map[string]PoolConfig{"generic": {Workers: 0}})
-	defer tp.Shutdown()
+	wp := NewWorkerPool(map[PoolName]PoolConfig{PoolGeneric: {Workers: 0}})
+	defer wp.Shutdown()
 
-	transport := NewTcpTransport(node, handlers, respHandlers, tp)
+	transport := NewTcpTransport(node, handlers, respHandlers, wp)
 
 	addr, err := transport.Start("127.0.0.1:0")
 	if err != nil {
@@ -33,10 +33,10 @@ func TestTcpTransport_Handshake(t *testing.T) {
 	serverNode := DiscoveryNode{ID: "server-1", Name: "server", Address: "127.0.0.1:0"}
 	handlers := NewRequestHandlerMap()
 	respHandlers := NewResponseHandlers()
-	tp := NewThreadPool(map[string]PoolConfig{"generic": {Workers: 0}})
-	defer tp.Shutdown()
+	wp := NewWorkerPool(map[PoolName]PoolConfig{PoolGeneric: {Workers: 0}})
+	defer wp.Shutdown()
 
-	server := NewTcpTransport(serverNode, handlers, respHandlers, tp)
+	server := NewTcpTransport(serverNode, handlers, respHandlers, wp)
 
 	addr, err := server.Start("127.0.0.1:0")
 	if err != nil {
@@ -46,7 +46,7 @@ func TestTcpTransport_Handshake(t *testing.T) {
 
 	// Client transport
 	clientNode := DiscoveryNode{ID: "client-1", Name: "client", Address: "127.0.0.1:0"}
-	client := NewTcpTransport(clientNode, handlers, respHandlers, tp)
+	client := NewTcpTransport(clientNode, handlers, respHandlers, wp)
 
 	profile := ConnectionProfile{
 		ConnPerType:      map[ConnectionType]int{ConnTypeREG: 1},
@@ -65,12 +65,12 @@ func TestTcpTransport_Handshake(t *testing.T) {
 		t.Fatalf("expected negotiated version %d, got %d", CurrentTransportVersion, nc.version)
 	}
 
-	// Verify we can get a connection
-	conn, err := nc.Conn(ConnTypeREG)
+	// Verify we can get a writer
+	w, err := nc.ConnWriter(ConnTypeREG)
 	if err != nil {
-		t.Fatalf("Conn(REG) failed: %v", err)
+		t.Fatalf("ConnWriter(REG) failed: %v", err)
 	}
-	if conn == nil {
-		t.Fatal("expected non-nil connection")
+	if w == nil {
+		t.Fatal("expected non-nil writer")
 	}
 }

--- a/server/transport/test_helpers_test.go
+++ b/server/transport/test_helpers_test.go
@@ -1,0 +1,27 @@
+package transport
+
+import "fmt"
+
+// registerHandler is a test helper that creates a typed dispatch closure for request handlers.
+func registerHandler[T any](
+	m *RequestHandlerMap,
+	action string,
+	executor PoolName,
+	reader Reader[T],
+	handler func(request T, channel TransportChannel) error,
+) {
+	m.Register(&requestHandlerEntry{
+		action:   action,
+		executor: executor,
+		dispatch: func(payload *StreamInput, channel TransportChannel) {
+			req, err := reader(payload)
+			if err != nil {
+				channel.SendError(fmt.Errorf("deserialize request: %w", err))
+				return
+			}
+			if err := handler(req, channel); err != nil {
+				channel.SendError(err)
+			}
+		},
+	})
+}

--- a/server/transport/writeable.go
+++ b/server/transport/writeable.go
@@ -1,0 +1,9 @@
+package transport
+
+// Writeable is implemented by all types that can be serialized to the transport wire format.
+type Writeable interface {
+	WriteTo(out *StreamOutput) error
+}
+
+// Reader is a function that deserializes a value from a StreamInput.
+type Reader[T any] func(in *StreamInput) (T, error)


### PR DESCRIPTION
## Summary

Custom binary transport layer for inter-node communication, following Elasticsearch's transport architecture. This is the foundation for all distributed features (Phase 1 of multi-node distribution).

Closes #51

### What's included

- **Serialization primitives** — `StreamOutput`/`StreamInput` with VInt, VLong, GenericMap (type-tagged recursive map)
- **Wire protocol** — Custom binary framing with "ES" marker, request ID correlation, status flags
- **Executor model** — Named bounded worker pools (`search`, `index`, `generic`, `cluster_state`, `transport_worker`)
- **Connection management** — Multi-connection pools per node categorized by type (REG, BULK, STATE, RECOVERY, PING)
- **Handler dispatch** — Action-name-to-handler routing with type-safe generic registration
- **Handshake protocol** — Version negotiation on connection establishment
- **TransportService** — Top-level API with local node short-circuit and remote TCP dispatch
- **Representative Writeables** — Binary serialization for IndexDocument, GetDocument, Search request/response
- **Node integration** — TransportService wired into Node startup with CPU-aware thread pools

### Architecture

```
TransportService (top-level API)
├── ConnectionManager (node connection registry)
│   └── TcpTransport (TCP listener, accept, connect)
│       ├── OutboundHandler (serialize + send)
│       ├── InboundHandler (receive + dispatch)
│       └── Handshake (version negotiation)
├── RequestHandlerMap (action → handler registry)
├── ResponseHandlers (requestID → callback correlation)
└── ThreadPool (named bounded executor pools)
```

### Package structure

15 source files + 11 test files in `server/transport/` (~4,400 lines)

## Test plan

- [x] StreamOutput/StreamInput roundtrip tests for all primitive types
- [x] GenericMap roundtrip with nested maps, slices, all value types
- [x] Wire protocol header encode/decode roundtrip
- [x] Executor backpressure and shutdown tests
- [x] Handler registry typed dispatch test
- [x] TCP listener/connect with handshake verification
- [x] ConnectionManager connect/disconnect/lookup tests
- [x] TransportService local request dispatch
- [x] TransportService remote request dispatch (two-node TCP)
- [x] End-to-end IndexDocument over transport
- [x] End-to-end Search over transport
- [x] Full project regression: all 18 packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)