### PR TITLE
perf: reduce per-document allocation pressure in indexing path

### DIFF
--- a/analysis/analyzer.go
+++ b/analysis/analyzer.go
@@ -1,7 +1,5 @@
 package analysis
 
-import "strings"
-
 // Analyzer combines a Tokenizer and a chain of TokenFilters into a pipeline.
 type Analyzer struct {
 	tokenizer Tokenizer
@@ -17,7 +15,7 @@ func NewAnalyzer(tokenizer Tokenizer, filters ...TokenFilter) *Analyzer {
 
 // Analyze converts text into a sequence of tokens by running the full pipeline.
 func (a *Analyzer) Analyze(text string) ([]Token, error) {
-	tokens, err := a.tokenizer.Tokenize(strings.NewReader(text))
+	tokens, err := a.tokenizer.Tokenize(text)
 	if err != nil {
 		return nil, err
 	}

--- a/analysis/analyzer_bench_test.go
+++ b/analysis/analyzer_bench_test.go
@@ -13,7 +13,7 @@ func BenchmarkWhitespaceTokenizer(b *testing.B) {
 
 	b.ReportAllocs()
 	for b.Loop() {
-		tokens, err := tokenizer.Tokenize(strings.NewReader(text))
+		tokens, err := tokenizer.Tokenize(text)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -27,7 +27,7 @@ func BenchmarkNGramTokenizer(b *testing.B) {
 
 	b.ReportAllocs()
 	for b.Loop() {
-		tokens, err := tokenizer.Tokenize(strings.NewReader(text))
+		tokens, err := tokenizer.Tokenize(text)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -39,7 +39,7 @@ func BenchmarkLowerCaseFilter(b *testing.B) {
 	tokenizer := NewWhitespaceTokenizer()
 	filter := NewLowerCaseFilter()
 	text := "The Quick Brown Fox Jumps Over The Lazy Dog"
-	tokens, err := tokenizer.Tokenize(strings.NewReader(text))
+	tokens, err := tokenizer.Tokenize(text)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/analysis/analyzer_test.go
+++ b/analysis/analyzer_test.go
@@ -1,7 +1,6 @@
 package analysis
 
 import (
-	"strings"
 	"testing"
 )
 
@@ -32,7 +31,7 @@ func TestAnalyzer(t *testing.T) {
 
 func TestWhitespaceTokenizerPositions(t *testing.T) {
 	tokenizer := NewWhitespaceTokenizer()
-	tokens, _ := tokenizer.Tokenize(strings.NewReader("hello world"))
+	tokens, _ := tokenizer.Tokenize("hello world")
 
 	if tokens[0].StartOffset != 0 || tokens[0].EndOffset != 5 {
 		t.Errorf("token 0 offsets: expected [0,5], got [%d,%d]",
@@ -47,7 +46,7 @@ func TestWhitespaceTokenizerPositions(t *testing.T) {
 func TestWhitespaceTokenizerJapanese(t *testing.T) {
 	tokenizer := NewWhitespaceTokenizer()
 	// "東京 大阪" = 6 bytes + 1 byte space + 6 bytes = 13 bytes
-	tokens, err := tokenizer.Tokenize(strings.NewReader("東京 大阪"))
+	tokens, err := tokenizer.Tokenize("東京 大阪")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +72,7 @@ func TestWhitespaceTokenizerJapanese(t *testing.T) {
 
 func TestWhitespaceTokenizerMultipleSpaces(t *testing.T) {
 	tokenizer := NewWhitespaceTokenizer()
-	tokens, err := tokenizer.Tokenize(strings.NewReader("hello   world"))
+	tokens, err := tokenizer.Tokenize("hello   world")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +92,7 @@ func TestWhitespaceTokenizerMultipleSpaces(t *testing.T) {
 
 func TestWhitespaceTokenizerTabsAndMixed(t *testing.T) {
 	tokenizer := NewWhitespaceTokenizer()
-	tokens, err := tokenizer.Tokenize(strings.NewReader("hello\tworld\nhello"))
+	tokens, err := tokenizer.Tokenize("hello\tworld\nhello")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +109,7 @@ func TestWhitespaceTokenizerTabsAndMixed(t *testing.T) {
 
 func TestWhitespaceTokenizerLeadingTrailing(t *testing.T) {
 	tokenizer := NewWhitespaceTokenizer()
-	tokens, err := tokenizer.Tokenize(strings.NewReader("  hello world  "))
+	tokens, err := tokenizer.Tokenize("  hello world  ")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +132,7 @@ func TestWhitespaceTokenizerLeadingTrailing(t *testing.T) {
 
 func TestWhitespaceTokenizerOnlyWhitespace(t *testing.T) {
 	tokenizer := NewWhitespaceTokenizer()
-	tokens, err := tokenizer.Tokenize(strings.NewReader("   "))
+	tokens, err := tokenizer.Tokenize("   ")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +143,7 @@ func TestWhitespaceTokenizerOnlyWhitespace(t *testing.T) {
 
 func TestWhitespaceTokenizerEmpty(t *testing.T) {
 	tokenizer := NewWhitespaceTokenizer()
-	tokens, err := tokenizer.Tokenize(strings.NewReader(""))
+	tokens, err := tokenizer.Tokenize("")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +154,7 @@ func TestWhitespaceTokenizerEmpty(t *testing.T) {
 
 func TestWhitespaceTokenizerSingleChar(t *testing.T) {
 	tokenizer := NewWhitespaceTokenizer()
-	tokens, err := tokenizer.Tokenize(strings.NewReader("a"))
+	tokens, err := tokenizer.Tokenize("a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +172,7 @@ func TestWhitespaceTokenizerSingleChar(t *testing.T) {
 func TestWhitespaceTokenizerEmoji(t *testing.T) {
 	tokenizer := NewWhitespaceTokenizer()
 	// 🔍 is 4 bytes in UTF-8
-	tokens, err := tokenizer.Tokenize(strings.NewReader("hello 🔍 world"))
+	tokens, err := tokenizer.Tokenize("hello 🔍 world")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +201,7 @@ func TestWhitespaceTokenizerSpecialChars(t *testing.T) {
 	tokenizer := NewWhitespaceTokenizer()
 
 	// Hyphens, dots, underscores should not split
-	tokens, err := tokenizer.Tokenize(strings.NewReader("state-of-the-art node.js hello_world"))
+	tokens, err := tokenizer.Tokenize("state-of-the-art node.js hello_world")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,7 +218,7 @@ func TestWhitespaceTokenizerSpecialChars(t *testing.T) {
 
 func TestWhitespaceTokenizerAtSignsAndHashes(t *testing.T) {
 	tokenizer := NewWhitespaceTokenizer()
-	tokens, err := tokenizer.Tokenize(strings.NewReader("user@example.com #tag"))
+	tokens, err := tokenizer.Tokenize("user@example.com #tag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -236,7 +235,7 @@ func TestWhitespaceTokenizerAtSignsAndHashes(t *testing.T) {
 
 func TestWhitespaceTokenizerSymbolsOnly(t *testing.T) {
 	tokenizer := NewWhitespaceTokenizer()
-	tokens, err := tokenizer.Tokenize(strings.NewReader("@#$%"))
+	tokens, err := tokenizer.Tokenize("@#$%")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -251,7 +250,7 @@ func TestWhitespaceTokenizerSymbolsOnly(t *testing.T) {
 func TestWhitespaceTokenizerAccentedChars(t *testing.T) {
 	tokenizer := NewWhitespaceTokenizer()
 	// é is 2 bytes, ï is 2 bytes in UTF-8
-	tokens, err := tokenizer.Tokenize(strings.NewReader("café résumé naïve"))
+	tokens, err := tokenizer.Tokenize("café résumé naïve")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -273,7 +272,7 @@ func TestWhitespaceTokenizerAccentedChars(t *testing.T) {
 func TestWhitespaceTokenizerLongToken(t *testing.T) {
 	tokenizer := NewWhitespaceTokenizer()
 	long := "superlongwordwithoutanyspaces"
-	tokens, err := tokenizer.Tokenize(strings.NewReader(long))
+	tokens, err := tokenizer.Tokenize(long)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -287,7 +286,7 @@ func TestWhitespaceTokenizerLongToken(t *testing.T) {
 
 func TestWhitespaceTokenizerMixedScripts(t *testing.T) {
 	tokenizer := NewWhitespaceTokenizer()
-	tokens, err := tokenizer.Tokenize(strings.NewReader("hello 東京 world café"))
+	tokens, err := tokenizer.Tokenize("hello 東京 world café")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -305,7 +304,7 @@ func TestWhitespaceTokenizerMixedScripts(t *testing.T) {
 func TestWhitespaceTokenizerUnicodePunctuation(t *testing.T) {
 	tokenizer := NewWhitespaceTokenizer()
 	// 「」『』 are not whitespace, should stay as part of token
-	tokens, err := tokenizer.Tokenize(strings.NewReader("「東京」の『タワー』"))
+	tokens, err := tokenizer.Tokenize("「東京」の『タワー』")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -321,7 +320,7 @@ func TestWhitespaceTokenizerUnicodePunctuation(t *testing.T) {
 func TestWhitespaceTokenizerFullWidth(t *testing.T) {
 	tokenizer := NewWhitespaceTokenizer()
 	// Each full-width char is 3 bytes in UTF-8
-	tokens, err := tokenizer.Tokenize(strings.NewReader("ＨＥＬＬＯ"))
+	tokens, err := tokenizer.Tokenize("ＨＥＬＬＯ")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -339,7 +338,7 @@ func TestWhitespaceTokenizerFullWidth(t *testing.T) {
 
 func TestWhitespaceTokenizerBackslashes(t *testing.T) {
 	tokenizer := NewWhitespaceTokenizer()
-	tokens, err := tokenizer.Tokenize(strings.NewReader("path\\to\\file"))
+	tokens, err := tokenizer.Tokenize("path\\to\\file")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -354,7 +353,7 @@ func TestWhitespaceTokenizerBackslashes(t *testing.T) {
 func TestWhitespaceTokenizerCJKExtensionB(t *testing.T) {
 	tokenizer := NewWhitespaceTokenizer()
 	// 𠮷 is 4 bytes in UTF-8 (CJK Extension B)
-	tokens, err := tokenizer.Tokenize(strings.NewReader("𠮷野家"))
+	tokens, err := tokenizer.Tokenize("𠮷野家")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -372,7 +371,7 @@ func TestWhitespaceTokenizerCJKExtensionB(t *testing.T) {
 
 func TestWhitespaceTokenizerSlashes(t *testing.T) {
 	tokenizer := NewWhitespaceTokenizer()
-	tokens, err := tokenizer.Tokenize(strings.NewReader("TCP/IP input/output"))
+	tokens, err := tokenizer.Tokenize("TCP/IP input/output")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/analysis/ngram_tokenizer.go
+++ b/analysis/ngram_tokenizer.go
@@ -1,7 +1,5 @@
 package analysis
 
-import "io"
-
 // NGramTokenizer generates all character n-grams of sizes minGram to maxGram.
 type NGramTokenizer struct {
 	minGram int
@@ -15,12 +13,7 @@ func NewNGramTokenizer(minGram, maxGram int) *NGramTokenizer {
 	}
 }
 
-func (t *NGramTokenizer) Tokenize(reader io.Reader) ([]Token, error) {
-	data, err := io.ReadAll(reader)
-	if err != nil {
-		return nil, err
-	}
-	text := string(data)
+func (t *NGramTokenizer) Tokenize(text string) ([]Token, error) {
 	runes := []rune(text)
 
 	var tokens []Token

--- a/analysis/ngram_tokenizer_test.go
+++ b/analysis/ngram_tokenizer_test.go
@@ -1,13 +1,12 @@
 package analysis
 
 import (
-	"strings"
 	"testing"
 )
 
 func TestNGramTokenizer(t *testing.T) {
 	tokenizer := NewNGramTokenizer(2, 3)
-	tokens, err := tokenizer.Tokenize(strings.NewReader("abc"))
+	tokens, err := tokenizer.Tokenize("abc")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,7 +27,7 @@ func TestNGramTokenizer(t *testing.T) {
 
 func TestNGramTokenizerOffsets(t *testing.T) {
 	tokenizer := NewNGramTokenizer(2, 2)
-	tokens, err := tokenizer.Tokenize(strings.NewReader("abcd"))
+	tokens, err := tokenizer.Tokenize("abcd")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +49,7 @@ func TestNGramTokenizerOffsets(t *testing.T) {
 
 func TestNGramTokenizerShortInput(t *testing.T) {
 	tokenizer := NewNGramTokenizer(2, 3)
-	tokens, err := tokenizer.Tokenize(strings.NewReader("a"))
+	tokens, err := tokenizer.Tokenize("a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +60,7 @@ func TestNGramTokenizerShortInput(t *testing.T) {
 
 func TestNGramTokenizerEmpty(t *testing.T) {
 	tokenizer := NewNGramTokenizer(2, 3)
-	tokens, err := tokenizer.Tokenize(strings.NewReader(""))
+	tokens, err := tokenizer.Tokenize("")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +71,7 @@ func TestNGramTokenizerEmpty(t *testing.T) {
 
 func TestNGramTokenizerJapanese(t *testing.T) {
 	tokenizer := NewNGramTokenizer(2, 3)
-	tokens, err := tokenizer.Tokenize(strings.NewReader("東京都"))
+	tokens, err := tokenizer.Tokenize("東京都")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +92,7 @@ func TestNGramTokenizerJapanese(t *testing.T) {
 
 func TestNGramTokenizerExactMinGram(t *testing.T) {
 	tokenizer := NewNGramTokenizer(2, 3)
-	tokens, err := tokenizer.Tokenize(strings.NewReader("ab"))
+	tokens, err := tokenizer.Tokenize("ab")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +111,7 @@ func TestNGramTokenizerExactMinGram(t *testing.T) {
 func TestNGramTokenizerMixedByteWidth(t *testing.T) {
 	tokenizer := NewNGramTokenizer(2, 2)
 	// "aあ🔍" = a(1 byte) + あ(3 bytes) + 🔍(4 bytes) = 8 bytes, 3 runes
-	tokens, err := tokenizer.Tokenize(strings.NewReader("aあ🔍"))
+	tokens, err := tokenizer.Tokenize("aあ🔍")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -139,7 +138,7 @@ func TestNGramTokenizerMixedByteWidth(t *testing.T) {
 func TestNGramTokenizerEmojiOffsets(t *testing.T) {
 	tokenizer := NewNGramTokenizer(2, 2)
 	// "🔍🔎" = 4 + 4 = 8 bytes, 2 runes
-	tokens, err := tokenizer.Tokenize(strings.NewReader("🔍🔎"))
+	tokens, err := tokenizer.Tokenize("🔍🔎")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +156,7 @@ func TestNGramTokenizerEmojiOffsets(t *testing.T) {
 func TestNGramTokenizerCJKExtensionB(t *testing.T) {
 	tokenizer := NewNGramTokenizer(2, 2)
 	// 𠮷(4 bytes) + 野(3 bytes) + 家(3 bytes) = 10 bytes, 3 runes
-	tokens, err := tokenizer.Tokenize(strings.NewReader("𠮷野家"))
+	tokens, err := tokenizer.Tokenize("𠮷野家")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,7 +183,7 @@ func TestNGramTokenizerCJKExtensionB(t *testing.T) {
 func TestNGramTokenizerWhitespaceInInput(t *testing.T) {
 	tokenizer := NewNGramTokenizer(2, 2)
 	// NGram tokenizer doesn't split on whitespace - it generates ngrams of the whole input
-	tokens, err := tokenizer.Tokenize(strings.NewReader("a b"))
+	tokens, err := tokenizer.Tokenize("a b")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +201,7 @@ func TestNGramTokenizerWhitespaceInInput(t *testing.T) {
 
 func TestNGramTokenizerSpecialChars(t *testing.T) {
 	tokenizer := NewNGramTokenizer(2, 2)
-	tokens, err := tokenizer.Tokenize(strings.NewReader("@#$"))
+	tokens, err := tokenizer.Tokenize("@#$")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,7 +218,7 @@ func TestNGramTokenizerJapaneseOffsets(t *testing.T) {
 	tokenizer := NewNGramTokenizer(2, 2)
 	// Each Japanese character is 3 bytes in UTF-8
 	// "東京都" = 9 bytes total
-	tokens, err := tokenizer.Tokenize(strings.NewReader("東京都"))
+	tokens, err := tokenizer.Tokenize("東京都")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/analysis/tokenizer.go
+++ b/analysis/tokenizer.go
@@ -1,10 +1,8 @@
 package analysis
 
-import "io"
-
 // Tokenizer splits text into a sequence of tokens.
 type Tokenizer interface {
-	Tokenize(reader io.Reader) ([]Token, error)
+	Tokenize(text string) ([]Token, error)
 }
 
 // WhitespaceTokenizer splits text by whitespace characters.
@@ -14,14 +12,8 @@ func NewWhitespaceTokenizer() *WhitespaceTokenizer {
 	return &WhitespaceTokenizer{}
 }
 
-func (t *WhitespaceTokenizer) Tokenize(reader io.Reader) ([]Token, error) {
-	data, err := io.ReadAll(reader)
-	if err != nil {
-		return nil, err
-	}
-	text := string(data)
-
-	var tokens []Token
+func (t *WhitespaceTokenizer) Tokenize(text string) ([]Token, error) {
+	tokens := make([]Token, 0, len(text)/5)
 	position := 0
 	start := 0
 	inToken := false

--- a/fst/builder.go
+++ b/fst/builder.go
@@ -39,6 +39,11 @@ func newNodeCache(limit int) nodeCache {
 	}
 }
 
+func (c *nodeCache) reset() {
+	clear(c.m)
+	c.cursor = 0
+}
+
 func (c *nodeCache) get(h uint64) (int64, bool) {
 	addr, ok := c.m[h]
 	return addr, ok
@@ -99,6 +104,23 @@ func NewBuilderWithWriter(w io.Writer) *Builder {
 	}
 	b.frontier = append(b.frontier, newUncompiledNode())
 	return b
+}
+
+// Reset resets the builder for reuse with a new writer, avoiding reallocation
+// of internal structures (frontier, cache).
+func (b *Builder) Reset(w io.Writer) {
+	b.w = w
+	b.written = 0
+	b.lastKey = b.lastKey[:0]
+	b.cache.reset()
+	b.count = 0
+	// Keep frontier slice but reset the root node
+	if len(b.frontier) > 0 {
+		b.frontier[0].clear()
+		b.frontier = b.frontier[:1]
+	} else {
+		b.frontier = append(b.frontier, newUncompiledNode())
+	}
 }
 
 // Add adds a key-value pair to the FST. Keys must be added in strictly sorted order.

--- a/fst/fst_test.go
+++ b/fst/fst_test.go
@@ -489,3 +489,75 @@ func TestManyKeys(t *testing.T) {
 		t.Error("Get(term9999): should not exist")
 	}
 }
+
+func TestBuilderReset(t *testing.T) {
+	// Build first FST
+	buf1 := &bytes.Buffer{}
+	b := NewBuilderWithWriter(buf1)
+	b.Add([]byte("alpha"), 1)
+	b.Add([]byte("beta"), 2)
+	if err := b.Finish(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Load first FST
+	path1 := filepath.Join(t.TempDir(), "fst1.bin")
+	if err := os.WriteFile(path1, buf1.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	input1, err := store.OpenMMap(path1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer input1.Close()
+	fst1, err := FSTFromInput(input1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Reset and build second FST
+	buf2 := &bytes.Buffer{}
+	b.Reset(buf2)
+	b.Add([]byte("delta"), 3)
+	b.Add([]byte("gamma"), 4)
+	if err := b.Finish(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Load second FST
+	path2 := filepath.Join(t.TempDir(), "fst2.bin")
+	if err := os.WriteFile(path2, buf2.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	input2, err := store.OpenMMap(path2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer input2.Close()
+	fst2, err := FSTFromInput(input2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify first FST
+	if v, ok := fst1.Get([]byte("alpha")); !ok || v != 1 {
+		t.Errorf("fst1.Get(alpha) = %d, %v; want 1, true", v, ok)
+	}
+	if v, ok := fst1.Get([]byte("beta")); !ok || v != 2 {
+		t.Errorf("fst1.Get(beta) = %d, %v; want 2, true", v, ok)
+	}
+	if _, ok := fst1.Get([]byte("gamma")); ok {
+		t.Error("fst1 should not contain gamma")
+	}
+
+	// Verify second FST
+	if v, ok := fst2.Get([]byte("delta")); !ok || v != 3 {
+		t.Errorf("fst2.Get(delta) = %d, %v; want 3, true", v, ok)
+	}
+	if v, ok := fst2.Get([]byte("gamma")); !ok || v != 4 {
+		t.Errorf("fst2.Get(gamma) = %d, %v; want 4, true", v, ok)
+	}
+	if _, ok := fst2.Get([]byte("alpha")); ok {
+		t.Error("fst2 should not contain alpha")
+	}
+}

--- a/index/dwpt.go
+++ b/index/dwpt.go
@@ -18,6 +18,7 @@ type DocumentsWriterPerThread struct {
 	deleteQueue    *DeleteQueue
 	deleteSlice    *DeleteSlice
 	pendingUpdates *BufferedUpdates
+	termInfo       map[string]*Posting // reused across documents
 }
 
 func newDWPT(segmentName string, fieldAnalyzers *analysis.FieldAnalyzers, deleteQueue *DeleteQueue) *DocumentsWriterPerThread {
@@ -27,6 +28,7 @@ func newDWPT(segmentName string, fieldAnalyzers *analysis.FieldAnalyzers, delete
 		deleteQueue:    deleteQueue,
 		deleteSlice:    deleteQueue.newSlice(),
 		pendingUpdates: newBufferedUpdates(),
+		termInfo:       make(map[string]*Posting),
 	}
 }
 
@@ -58,26 +60,31 @@ func (dwpt *DocumentsWriterPerThread) addDocument(doc *document.Document) (int64
 			seg.fieldLengths[field.Name][docID] = len(tokens)
 			bytesAdded += 4 // fieldLengths entry
 
-			termInfo := make(map[string]*Posting)
+			clear(dwpt.termInfo)
 			for _, token := range tokens {
-				posting, exists := termInfo[token.Term]
+				posting, exists := dwpt.termInfo[token.Term]
 				if !exists {
 					posting = &Posting{DocID: docID}
-					termInfo[token.Term] = posting
+					dwpt.termInfo[token.Term] = posting
 				}
 				posting.Freq++
 				posting.Positions = append(posting.Positions, token.Position)
 			}
 
-			for term, posting := range termInfo {
+			for term, posting := range dwpt.termInfo {
 				pl, exists := fi.postings[term]
 				if !exists {
-					pl = &PostingsList{Term: term}
+					pl = &PostingsList{Term: term, Postings: make([]Posting, 0, 8)}
 					fi.postings[term] = pl
 				}
 				pl.Postings = append(pl.Postings, *posting)
 				// term string + DocID(8) + Freq(8) + positions
 				bytesAdded += int64(len(term) + 16 + 8*len(posting.Positions))
+				// Reset the posting for reuse: keep the pointer in the map
+				// but clear fields so it's ready for the next document.
+				posting.DocID = 0
+				posting.Freq = 0
+				posting.Positions = nil
 			}
 
 		case document.FieldTypeKeyword:
@@ -261,6 +268,7 @@ func (dwpt *DocumentsWriterPerThread) reset(name string) {
 	dwpt.flushPending = false
 	dwpt.deleteSlice = dwpt.deleteQueue.newSlice()
 	dwpt.pendingUpdates = newBufferedUpdates()
+	clear(dwpt.termInfo)
 }
 
 func (dwpt *DocumentsWriterPerThread) getOrCreateFieldIndex(fieldName string) *FieldIndex {

--- a/index/merger.go
+++ b/index/merger.go
@@ -123,8 +123,9 @@ func MergeSegmentsToDisk(dir store.Directory, inputs []MergeInput, newName strin
 	files = append(files, newName+".stored")
 
 	// Merge postings per field.
+	fstBuilder := fst.NewBuilderWithWriter(nil)
 	for _, field := range allFields {
-		if err := mergeFieldPostingsToDisk(dir, newName, field, inputs, mapper); err != nil {
+		if err := mergeFieldPostingsToDisk(dir, newName, field, inputs, mapper, fstBuilder); err != nil {
 			return nil, err
 		}
 		files = append(files,
@@ -421,6 +422,7 @@ func mergeFieldPostingsToDisk(
 	segName, field string,
 	inputs []MergeInput,
 	mapper *DocIDMapper,
+	fstBuilder *fst.Builder,
 ) error {
 	// Initialize the heap with one entry per segment that has this field.
 	var h termHeap
@@ -465,7 +467,7 @@ func mergeFieldPostingsToDisk(
 	}
 	defer tfstOut.Close()
 
-	fstBuilder := fst.NewBuilderWithWriter(tfstOut)
+	fstBuilder.Reset(tfstOut)
 	var ordinal uint64
 	var globalTdatOffset uint64
 	var globalTposOffset uint64

--- a/index/segment_writer.go
+++ b/index/segment_writer.go
@@ -57,9 +57,10 @@ func WriteSegmentV2(dir store.Directory, seg *InMemorySegment) ([]string, []stri
 	files = append(files, metaFileName)
 
 	// 2. Write postings (tidx + tfst + tdat) for each field
+	fstBuilder := fst.NewBuilderWithWriter(nil) // will be Reset per field
 	for _, fieldName := range meta.Fields {
 		fi := seg.fields[fieldName]
-		if err := writeFieldPostingsV2(dir, seg.name, fieldName, fi); err != nil {
+		if err := writeFieldPostingsV2(dir, seg.name, fieldName, fi, fstBuilder); err != nil {
 			return nil, nil, err
 		}
 		files = append(files,
@@ -275,7 +276,7 @@ func writeStoredFieldsEntry(out store.IndexOutput, fields map[string][]byte, scr
 //	  position_count: VInt
 //	  position_delta: VInt × N
 //	]
-func writeFieldPostingsV2(dir store.Directory, segName, fieldName string, fi *FieldIndex) error {
+func writeFieldPostingsV2(dir store.Directory, segName, fieldName string, fi *FieldIndex, fstBuilder *fst.Builder) error {
 	if len(fi.postings) == 0 {
 		return nil
 	}
@@ -300,7 +301,7 @@ func writeFieldPostingsV2(dir store.Directory, segName, fieldName string, fi *Fi
 	}
 	defer tfstOut.Close()
 
-	fstBuilder := fst.NewBuilderWithWriter(tfstOut)
+	fstBuilder.Reset(tfstOut)
 
 	for i, term := range terms {
 		pl := fi.postings[term]


### PR DESCRIPTION
## Summary

Closes #60

- Change `Tokenizer` interface from `io.Reader` to `string`, eliminating 2 unnecessary copies per tokenization call and pre-allocating token slices with `len(text)/5` capacity estimate
- Reuse `termInfo` map on DWPT across documents via `clear()` instead of allocating a new map per field per document; pre-size `PostingsList.Postings` with capacity 8
- Add `Builder.Reset()` to FST builder for reuse across fields within a segment write, avoiding repeated allocation of the 100K-entry nodeCache map

### Benchmark results (1 goroutine, 100K docs)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| total-alloc-MB | 1495 | 1100 | **-26%** |
| B/op | 1,567M | 1,153M | **-26%** |
| allocs/op | 12.84M | 10.94M | **-15%** |
| ns/op | 956M | 802M | **-16%** |
| docs/sec | 52,400 | 62,400 | **+19%** |

## Test plan

- [x] All existing tests pass (`go test ./... -count=1`)
- [x] `TestBuilderReset` added for FST builder reuse correctness
- [x] `BenchmarkConcurrentIndex` confirms allocation reduction across 1/2/4/8 goroutines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>