### PR TITLE
fix: use Murmur3 hash for shard routing (ES compatibility)

### DIFF
--- a/server/index/engine_test.go
+++ b/server/index/engine_test.go
@@ -408,6 +408,28 @@ func TestRouteShard(t *testing.T) {
 	if index.RouteShard("anything", 1) != 0 {
 		t.Fatal("single shard must return 0")
 	}
+
+	// ES-compatible shard assignments (Murmur3 + floorMod)
+	esTests := []struct {
+		id        string
+		numShards int
+		want      int
+	}{
+		{"doc1", 5, 2},
+		{"doc2", 5, 4},
+		{"test", 5, 1},
+		{"hello", 5, 1},
+		{"elasticsearch", 5, 0},
+		{"0", 5, 1},
+		{"1", 5, 3},
+		{"12345", 5, 3},
+	}
+	for _, tt := range esTests {
+		got := index.RouteShard(tt.id, tt.numShards)
+		if got != tt.want {
+			t.Errorf("RouteShard(%q, %d) = %d, want %d (ES-compatible)", tt.id, tt.numShards, got, tt.want)
+		}
+	}
 }
 
 func TestEngine_IndexAndSearchSpecialChars(t *testing.T) {

--- a/server/index/murmur3.go
+++ b/server/index/murmur3.go
@@ -1,0 +1,55 @@
+package index
+
+import "encoding/binary"
+
+// Murmur3Hash computes MurmurHash3 x86 32-bit, matching Lucene's
+// StringHelper.murmurhash3_x86_32 used by Elasticsearch for shard routing.
+func Murmur3Hash(data []byte, seed int32) int32 {
+	const (
+		c1 = 0xcc9e2d51
+		c2 = 0x1b873593
+	)
+
+	h1 := uint32(seed)
+	length := len(data)
+	roundedEnd := length & ^3 // round down to 4-byte block boundary
+
+	// Body: process 4-byte blocks
+	for i := 0; i < roundedEnd; i += 4 {
+		k1 := binary.LittleEndian.Uint32(data[i:])
+		k1 *= c1
+		k1 = (k1 << 15) | (k1 >> 17)
+		k1 *= c2
+
+		h1 ^= k1
+		h1 = (h1 << 13) | (h1 >> 19)
+		h1 = h1*5 + 0xe6546b64
+	}
+
+	// Tail: process remaining bytes
+	var k1 uint32
+	switch length & 3 {
+	case 3:
+		k1 ^= uint32(data[roundedEnd+2]) << 16
+		fallthrough
+	case 2:
+		k1 ^= uint32(data[roundedEnd+1]) << 8
+		fallthrough
+	case 1:
+		k1 ^= uint32(data[roundedEnd])
+		k1 *= c1
+		k1 = (k1 << 15) | (k1 >> 17)
+		k1 *= c2
+		h1 ^= k1
+	}
+
+	// Finalization mix
+	h1 ^= uint32(length)
+	h1 ^= h1 >> 16
+	h1 *= 0x85ebca6b
+	h1 ^= h1 >> 13
+	h1 *= 0xc2b2ae35
+	h1 ^= h1 >> 16
+
+	return int32(h1)
+}

--- a/server/index/murmur3_test.go
+++ b/server/index/murmur3_test.go
@@ -1,0 +1,52 @@
+package index
+
+import (
+	"testing"
+)
+
+func TestMurmur3Hash(t *testing.T) {
+	// Reference values from Lucene's StringHelper.murmurhash3_x86_32 with seed=0.
+	// These match Elasticsearch's Murmur3HashFunction.hash().
+	tests := []struct {
+		input string
+		want  int32
+	}{
+		{"", 0},
+		{"test", -1167338989},
+		{"hello", 613153351},
+		{"doc1", -657533388},
+		{"doc2", -1895630836},
+		{"abc", -1277324294},
+		{"elasticsearch", 1171729715},
+		{"0", -764297089},
+		{"1", -1810453357},
+		{"12345", 329585043},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := Murmur3Hash([]byte(tt.input), 0)
+			if got != tt.want {
+				t.Errorf("Murmur3Hash(%q, 0) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMurmur3Hash_Deterministic(t *testing.T) {
+	data := []byte("consistency-check")
+	h1 := Murmur3Hash(data, 0)
+	h2 := Murmur3Hash(data, 0)
+	if h1 != h2 {
+		t.Fatalf("non-deterministic: %d != %d", h1, h2)
+	}
+}
+
+func TestMurmur3Hash_DifferentSeeds(t *testing.T) {
+	data := []byte("test")
+	h0 := Murmur3Hash(data, 0)
+	h1 := Murmur3Hash(data, 42)
+	if h0 == h1 {
+		t.Fatal("different seeds should produce different hashes")
+	}
+}

--- a/server/index/service.go
+++ b/server/index/service.go
@@ -2,7 +2,6 @@ package index
 
 import (
 	"fmt"
-	"hash/fnv"
 	"path/filepath"
 	"time"
 
@@ -127,9 +126,13 @@ func (is *IndexService) scheduleRefresh(interval time.Duration) {
 	}
 }
 
-// RouteShard returns the shard ID for a given document ID using consistent hashing.
+// RouteShard returns the shard ID for a given document ID using Murmur3 hashing,
+// matching Elasticsearch's shard routing (Murmur3HashFunction + Math.floorMod).
 func RouteShard(id string, numShards int) int {
-	h := fnv.New32a()
-	h.Write([]byte(id))
-	return int(h.Sum32() % uint32(numShards))
+	hash := int(Murmur3Hash([]byte(id), 0))
+	mod := hash % numShards
+	if mod < 0 {
+		mod += numShards
+	}
+	return mod
 }


### PR DESCRIPTION
## Summary

- Replace FNV-32a with Lucene's `murmurhash3_x86_32` (seed=0) in `RouteShard`, so documents land on the same shards as Elasticsearch
- Use `floorMod` semantics to correctly handle negative hash values
- Add 12 unit tests for the Murmur3 hash function verified against ES/Lucene reference values, plus 8 ES-compatible shard assignment assertions

Closes #42

## Test plan

- [x] `TestMurmur3Hash` — 10 inputs verified against Lucene's `StringHelper.murmurhash3_x86_32` output
- [x] `TestMurmur3Hash_Deterministic` — same input always produces same hash
- [x] `TestMurmur3Hash_DifferentSeeds` — different seeds produce different hashes
- [x] `TestRouteShard` — determinism, range check, single-shard, and 8 ES-compatible shard assignments
- [x] Full test suite passes (16 packages, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)